### PR TITLE
Add virtual faction aliases to other components

### DIFF
--- a/f/assignGear/f_assignInsignia.sqf
+++ b/f/assignGear/f_assignInsignia.sqf
@@ -44,14 +44,14 @@ private _roleBadge = switch (_typeofUnit) do
 // INSIGNIA: MEDIC
 	case "m":
 	{
-		switch (_faction) do
+		switch (true) do
 		{
-			case ("blu_f" or "nato") : {_NATO_Medic_Badge};
-			case ("blu_t_f" or "blu_w_f" or "natopacific" or "natowoodland") : {"NATO_Pacific_Medic_Badge"}
-			case ("opf_f" or "csat") : {_CSAT_Medic_Badge};
-			case ("opf_t_f" or "csatpacific") : {"CSAT_Pacific_Medic_Badge"};
-			case ("ind_f" or "ind_e_f" or "aaf" or "ldf") : {"AAF_Medic_Badge"};
-			case ("opf_r_f" or "spetsnaz") : {"CSAT_Pacific_Medic_Badge"};
+			case (_faction in ["blu_f","nato"]) : {_NATO_Medic_Badge};
+			case (_faction in ["blu_t_f","blu_w_f","natopacific","natowoodland"]) : {"NATO_Pacific_Medic_Badge"};
+			case (_faction in ["opf_f","csat"]) : {_CSAT_Medic_Badge};
+			case (_faction in ["opf_t_f","csatpacific"]) : {"CSAT_Pacific_Medic_Badge"};
+			case (_faction in ["ind_f","ind_e_f","aaf","ldf"]) : {"AAF_Medic_Badge"};
+			case (_faction in ["opf_r_f","spetsnaz"]) : {"CSAT_Pacific_Medic_Badge"};
 			default {"NATO_Medic_Badge"};
 		};
 	};
@@ -65,9 +65,9 @@ private _roleBadge = switch (_typeofUnit) do
 
 private _groupBadges = [];
 
-switch (_faction) do
+switch (true) do
 {
-	case ("blu_f" or "nato") : {
+	case (_faction in ["blu_f","nato"]) : {
 		if (_insignia_style_NATO == "Tanoa") then {
 			_groupBadges = [
 				["GrpNATO_ASL","NATO_Pacific_ASL_Badge"],
@@ -104,7 +104,7 @@ switch (_faction) do
 			];
 		};
 	};
-	case ("blu_t_f" or "blu_w_f" or "natoPacific" or "natoWoodland"): {
+	case (_faction in ["blu_t_f","blu_w_f","natoPacific","natoWoodland"]): {
 		_groupBadges = [
 			["GrpNATO_ASL","NATO_Pacific_ASL_Badge"],
 			["GrpNATO_A1","NATO_Pacific_A1_Badge"],
@@ -123,7 +123,7 @@ switch (_faction) do
 		];
 	};
 	
-	case ("opf_f" or "csat"): {
+	case (_faction in ["opf_f","csat"]): {
 		switch (_insignia_style_CSAT) do
 		{
 			case "Tanoa" : {
@@ -182,7 +182,7 @@ switch (_faction) do
 			};
 		};
 	};
-	case ("opf_t_f" or "csatPacific"): {
+	case (_faction in ["opf_t_f","csatPacific"]): {
 		_groupBadges = [
 			["GrpCSAT_ASL","CSAT_Pacific_ASL_Badge"],
 			["GrpCSAT_A1","CSAT_Pacific_A1_Badge"],
@@ -200,7 +200,7 @@ switch (_faction) do
 			["GrpCSAT_DC","CSAT_Pacific_DC_Badge"]
 		];
 	};
-	case ("opf_r_f" or "spetsnaz"): {
+	case (_faction in ["opf_r_f","spetsnaz"]): {
 		_groupBadges = [
 			["GrpSpetsnaz_ASL","CSAT_Pacific_ASL_Badge"],
 			["GrpSpetsnaz_A1","CSAT_Pacific_A1_Badge"],
@@ -218,7 +218,7 @@ switch (_faction) do
 			["GrpSpetsnaz_DC","CSAT_Pacific_DC_Badge"]
 		];
 	};
-	case ("ind_f" or "aaf"): {
+	case (_faction in ["ind_f","aaf"]): {
 		_groupBadges = [
 			["GrpAAF_ASL","AAF_ASL_Badge"],
 			["GrpAAF_A1","AAF_A1_Badge"],
@@ -236,7 +236,7 @@ switch (_faction) do
 			["GrpAAF_DC","AAF_DC_Badge"]
 		];
 	};
-	case ("ind_e_f" or "ldf"): {
+	case (_faction in ["ind_e_f","ldf"]): {
 		_groupBadges = [
 			["GrpLDF_ASL","AAF_ASL_Badge"],
 			["GrpLDF_A1","AAF_A1_Badge"],
@@ -254,7 +254,7 @@ switch (_faction) do
 			["GrpLDF_DC","AAF_DC_Badge"]
 		];
 	};
-	case ("blu_g_f" or "opf_g_f" or "ind_g_f" or "fia") : {
+	case (_faction in ["blu_g_f","opf_g_f","ind_g_f","fia"]) : {
 		_groupBadges = [
 			["GrpFIA_ASL","NATO_ASL_Badge"],
 			["GrpFIA_A1","NATO_A1_Badge"],
@@ -269,7 +269,7 @@ switch (_faction) do
 			["GrpFIA_C2","NATO_C2_Badge"],
 			["GrpFIA_C3","NATO_C3_Badge"],
 			["GrpFIA_CO","NATO_CO_Badge"],
-			["GrpFIA_DC","NATO_DC_Badge"]
+			["GrpFIA_DC","NATO_DC_Badge"],
 			
 			["GrpOFIA_ASL","NATO_ASL_Badge"],
 			["GrpOFIA_A1","NATO_A1_Badge"],
@@ -284,7 +284,7 @@ switch (_faction) do
 			["GrpOFIA_C2","NATO_C2_Badge"],
 			["GrpOFIA_C3","NATO_C3_Badge"],
 			["GrpOFIA_CO","NATO_CO_Badge"],
-			["GrpOFIA_DC","NATO_DC_Badge"]
+			["GrpOFIA_DC","NATO_DC_Badge"],
 			
 			["GrpIFIA_ASL","NATO_ASL_Badge"],
 			["GrpIFIA_A1","NATO_A1_Badge"],
@@ -302,7 +302,7 @@ switch (_faction) do
 			["GrpIFIA_DC","NATO_DC_Badge"]
 		];
 	};
-	case ("ind_c_f" or "syndikat") :{
+	case (_faction in ["ind_c_f","syndikat"]) :{
 		_groupBadges = [
 			["GrpSyndikat_ASL","NATO_ASL_Badge"],
 			["GrpSyndikat_A1","NATO_A1_Badge"],
@@ -320,7 +320,7 @@ switch (_faction) do
 			["GrpSyndikat_DC","NATO_DC_Badge"]
 		];
 	};
-	case ("ind_l_f" or "npr") :{
+	case (_faction in ["ind_l_f","npr"]) :{
 		_groupBadges = [
 			["GrpNPR_ASL","NATO_ASL_Badge"],
 			["GrpNPR_A1","NATO_A1_Badge"],
@@ -338,7 +338,7 @@ switch (_faction) do
 			["GrpNPR_DC","NATO_DC_Badge"]
 		];
 	};
-	case "3ifb" :{
+	case (_faction in ["3ifb"]) :{
 		_groupBadges = [
 			["Grp3IFB_ASL","NATO_ASL_Badge"],
 			["Grp3IFB_A1","NATO_A1_Badge"],

--- a/f/assignGear/f_assignInsignia.sqf
+++ b/f/assignGear/f_assignInsignia.sqf
@@ -32,7 +32,7 @@ switch (_insignia_style_CSAT) do
 	};
 
 // Treat CTRG like BLUFOR
-if (_faction == "blu_ctrg_f") then {_faction = "blu_f"};
+if (_faction in ["blu_ctrg_f","ctrg"]) then {_faction = "blu_f"};
 
 // ===================================================================================
 
@@ -46,12 +46,12 @@ private _roleBadge = switch (_typeofUnit) do
 	{
 		switch (_faction) do
 		{
-			case "blu_f" : {_NATO_Medic_Badge};
-			case "opf_f" : {_CSAT_Medic_Badge};
-			case "ind_f" : {"AAF_Medic_Badge"};
-			case "ind_e_f" : {"AAF_Medic_Badge"};
-			case "opf_r_f" : {"CSAT_Pacific_Medic_Badge"};
-			case "blu_w_f" : {"NATO_Pacific_Medic_Bade"};
+			case ("blu_f" or "nato") : {_NATO_Medic_Badge};
+			case ("blu_t_f" or "blu_w_f" or "natopacific" or "natowoodland") : {"NATO_Pacific_Medic_Badge"}
+			case ("opf_f" or "csat") : {_CSAT_Medic_Badge};
+			case ("opf_t_f" or "csatpacific") : {"CSAT_Pacific_Medic_Badge"};
+			case ("ind_f" or "ind_e_f" or "aaf" or "ldf") : {"AAF_Medic_Badge"};
+			case ("opf_r_f" or "spetsnaz") : {"CSAT_Pacific_Medic_Badge"};
 			default {"NATO_Medic_Badge"};
 		};
 	};
@@ -67,7 +67,7 @@ private _groupBadges = [];
 
 switch (_faction) do
 {
-	case "blu_f" : {
+	case ("blu_f" or "nato") : {
 		if (_insignia_style_NATO == "Tanoa") then {
 			_groupBadges = [
 				["GrpNATO_ASL","NATO_Pacific_ASL_Badge"],
@@ -104,7 +104,7 @@ switch (_faction) do
 			];
 		};
 	};
-	case "blu_t_f": {
+	case ("blu_t_f" or "blu_w_f" or "natoPacific" or "natoWoodland"): {
 		_groupBadges = [
 			["GrpNATO_ASL","NATO_Pacific_ASL_Badge"],
 			["GrpNATO_A1","NATO_Pacific_A1_Badge"],
@@ -122,25 +122,8 @@ switch (_faction) do
 			["GrpNATO_DC","NATO_Pacific_DC_Badge"]
 		];
 	};
-	case "blu_w_f": {
-		_groupBadges = [
-			["GrpNATO_ASL","NATO_Pacific_ASL_Badge"],
-			["GrpNATO_A1","NATO_Pacific_A1_Badge"],
-			["GrpNATO_A2","NATO_Pacific_A2_Badge"],
-			["GrpNATO_A3","NATO_Pacific_A3_Badge"],
-			["GrpNATO_BSL","NATO_Pacific_BSL_Badge"],
-			["GrpNATO_B1","NATO_Pacific_B1_Badge"],
-			["GrpNATO_B2","NATO_Pacific_B2_Badge"],
-			["GrpNATO_B3","NATO_Pacific_B3_Badge"],
-			["GrpNATO_CSL","NATO_Pacific_CSL_Badge"],
-			["GrpNATO_C1","NATO_Pacific_C1_Badge"],
-			["GrpNATO_C2","NATO_Pacific_C2_Badge"],
-			["GrpNATO_C3","NATO_Pacific_C3_Badge"],
-			["GrpNATO_CO","NATO_Pacific_CO_Badge"],
-			["GrpNATO_DC","NATO_Pacific_DC_Badge"]
-		];
-	};
-	case "opf_f": {
+	
+	case ("opf_f" or "csat"): {
 		switch (_insignia_style_CSAT) do
 		{
 			case "Tanoa" : {
@@ -199,7 +182,7 @@ switch (_faction) do
 			};
 		};
 	};
-	case "opf_t_f": {
+	case ("opf_t_f" or "csatPacific"): {
 		_groupBadges = [
 			["GrpCSAT_ASL","CSAT_Pacific_ASL_Badge"],
 			["GrpCSAT_A1","CSAT_Pacific_A1_Badge"],
@@ -217,7 +200,7 @@ switch (_faction) do
 			["GrpCSAT_DC","CSAT_Pacific_DC_Badge"]
 		];
 	};
-	case "opf_r_f": {
+	case ("opf_r_f" or "spetsnaz"): {
 		_groupBadges = [
 			["GrpSpetsnaz_ASL","CSAT_Pacific_ASL_Badge"],
 			["GrpSpetsnaz_A1","CSAT_Pacific_A1_Badge"],
@@ -235,7 +218,7 @@ switch (_faction) do
 			["GrpSpetsnaz_DC","CSAT_Pacific_DC_Badge"]
 		];
 	};
-	case "ind_f": {
+	case ("ind_f" or "aaf"): {
 		_groupBadges = [
 			["GrpAAF_ASL","AAF_ASL_Badge"],
 			["GrpAAF_A1","AAF_A1_Badge"],
@@ -253,7 +236,7 @@ switch (_faction) do
 			["GrpAAF_DC","AAF_DC_Badge"]
 		];
 	};
-	case "ind_e_f": {
+	case ("ind_e_f" or "ldf"): {
 		_groupBadges = [
 			["GrpLDF_ASL","AAF_ASL_Badge"],
 			["GrpLDF_A1","AAF_A1_Badge"],
@@ -271,7 +254,7 @@ switch (_faction) do
 			["GrpLDF_DC","AAF_DC_Badge"]
 		];
 	};
-	case "blu_g_f" : {
+	case ("blu_g_f" or "opf_g_f" or "ind_g_f" or "fia") : {
 		_groupBadges = [
 			["GrpFIA_ASL","NATO_ASL_Badge"],
 			["GrpFIA_A1","NATO_A1_Badge"],
@@ -287,10 +270,7 @@ switch (_faction) do
 			["GrpFIA_C3","NATO_C3_Badge"],
 			["GrpFIA_CO","NATO_CO_Badge"],
 			["GrpFIA_DC","NATO_DC_Badge"]
-		];
-	};
-	case "opf_g_f" :{
-		_groupBadges = [
+			
 			["GrpOFIA_ASL","NATO_ASL_Badge"],
 			["GrpOFIA_A1","NATO_A1_Badge"],
 			["GrpOFIA_A2","NATO_A2_Badge"],
@@ -305,10 +285,7 @@ switch (_faction) do
 			["GrpOFIA_C3","NATO_C3_Badge"],
 			["GrpOFIA_CO","NATO_CO_Badge"],
 			["GrpOFIA_DC","NATO_DC_Badge"]
-		];
-	};
-	case "ind_g_f" :{
-		_groupBadges = [
+			
 			["GrpIFIA_ASL","NATO_ASL_Badge"],
 			["GrpIFIA_A1","NATO_A1_Badge"],
 			["GrpIFIA_A2","NATO_A2_Badge"],
@@ -325,7 +302,7 @@ switch (_faction) do
 			["GrpIFIA_DC","NATO_DC_Badge"]
 		];
 	};
-	case "ind_c_f" :{
+	case ("ind_c_f" or "syndikat") :{
 		_groupBadges = [
 			["GrpSyndikat_ASL","NATO_ASL_Badge"],
 			["GrpSyndikat_A1","NATO_A1_Badge"],
@@ -343,7 +320,7 @@ switch (_faction) do
 			["GrpSyndikat_DC","NATO_DC_Badge"]
 		];
 	};
-	case "ind_l_f" :{
+	case ("ind_l_f" or "npr") :{
 		_groupBadges = [
 			["GrpNPR_ASL","NATO_ASL_Badge"],
 			["GrpNPR_A1","NATO_A1_Badge"],

--- a/f/assignGear/f_assignInsignia.sqf
+++ b/f/assignGear/f_assignInsignia.sqf
@@ -31,9 +31,6 @@ switch (_insignia_style_CSAT) do
 	case "Urban" : {_CSAT_Medic_Badge = "CSAT_Urban_Medic_Badge";};
 	};
 
-// Treat CTRG like BLUFOR
-if (_faction in ["blu_ctrg_f","ctrg"]) then {_faction = "blu_f"};
-
 // ===================================================================================
 
 // Assign Insignia based on type of the unit.
@@ -52,6 +49,7 @@ private _roleBadge = switch (_typeofUnit) do
 			case (_faction in ["opf_t_f","csatpacific"]) : {"CSAT_Pacific_Medic_Badge"};
 			case (_faction in ["ind_f","ind_e_f","aaf","ldf"]) : {"AAF_Medic_Badge"};
 			case (_faction in ["opf_r_f","spetsnaz"]) : {"CSAT_Pacific_Medic_Badge"};
+			case (_faction in ["blu_ctrg_f","ctrg"]) : {_NATO_Medic_Badge"};
 			default {"NATO_Medic_Badge"};
 		};
 	};
@@ -252,6 +250,24 @@ switch (true) do
 			["GrpLDF_C3","AAF_C3_Badge"],
 			["GrpLDF_CO","AAF_CO_Badge"],
 			["GrpLDF_DC","AAF_DC_Badge"]
+		];
+	};
+	case (_faction in ["blu_ctrg_f","ctrg"]): {
+		_groupBadges = [
+			["GrpCTRG_ASL","NATO_ASL_Badge"],
+			["GrpCTRG_A1","NATO_A1_Badge"],
+			["GrpCTRG_A2","NATO_A2_Badge"],
+			["GrpCTRG_A3","NATO_A3_Badge"],
+			["GrpCTRG_BSL","NATO_BSL_Badge"],
+			["GrpCTRG_B1","NATO_B1_Badge"],
+			["GrpCTRG_B2","NATO_B2_Badge"],
+			["GrpCTRG_B3","NATO_B3_Badge"],
+			["GrpCTRG_CSL","NATO_CSL_Badge"],
+			["GrpCTRG_C1","NATO_C1_Badge"],
+			["GrpCTRG_C2","NATO_C2_Badge"],
+			["GrpCTRG_C3","NATO_C3_Badge"],
+			["GrpCTRG_CO","NATO_CO_Badge"],
+			["GrpCTRG_DC","NATO_DC_Badge"]
 		];
 	};
 	case (_faction in ["blu_g_f","opf_g_f","ind_g_f","fia"]) : {

--- a/f/briefing/fn_createBriefing.sqf
+++ b/f/briefing/fn_createBriefing.sqf
@@ -49,13 +49,13 @@ if (serverCommandAvailable "#kick" || !isMultiplayer) then {
 // The following code blocks include faction-specific briefing files.
 
 // BLUFOR > NATO
-if (_unitfaction in ["blu_f","blu_t_f","blu_w_f"]) exitwith {
+if (_unitfaction in ["blu_f","blu_t_f","blu_w_f","nato","natowoodland","natopacific"]) exitwith {
 	#include "f_briefing_nato.sqf"
 	[_unitfaction] call _fnc_debug;
 };
 
 // FIA
-if (_unitfaction in ["blu_g_f","ind_g_f","opf_g_f"]) exitwith {
+if (_unitfaction in ["blu_g_f","ind_g_f","opf_g_f","fia"]) exitwith {
 	#include "f_briefing_fia.sqf"
 	[_unitfaction] call _fnc_debug;
 };
@@ -67,44 +67,44 @@ if (_unitfaction in ["blu_gen_f"]) exitwith {
 };
 
 // OPFOR > CSAT
-if (_unitfaction in ["opf_f","opf_t_f"]) exitwith {
+if (_unitfaction in ["opf_f","opf_t_f","csat","csatpacific"]) exitwith {
 	#include "f_briefing_csat.sqf"
 	[_unitfaction] call _fnc_debug;
 };
 
 // OPFOR > Spetsnaz
-if (_unitfaction in ["opf_r_f"]) exitwith {
+if (_unitfaction in ["opf_r_f","spetsnaz"]) exitwith {
 	#include "f_briefing_spetsnaz.sqf"
 	[_unitfaction] call _fnc_debug;
 };
 
 // INDEPENDENT > AAF
-if (_unitfaction in ["ind_f"]) exitwith {
+if (_unitfaction in ["ind_f","aaf"]) exitwith {
 	#include "f_briefing_aaf.sqf"
 	[_unitfaction] call _fnc_debug;
 };
 
 // INDEPENDENT > LDF
-if (_unitfaction in ["ind_e_f"]) exitwith {
+if (_unitfaction in ["ind_e_f","ldf"]) exitwith {
 	#include "f_briefing_ldf.sqf"
 	[_unitfaction] call _fnc_debug;
 };
 
 // INDEPENDENT > SYNDIKAT
-if (_unitfaction in ["ind_c_f"]) exitwith {
+if (_unitfaction in ["ind_c_f","syndikat"]) exitwith {
 	#include "f_briefing_syndikat.sqf"
 	[_unitfaction] call _fnc_debug;
 };
 
 // INDEPENDENT > NPR (Looters)
-if (_unitfaction in ["ind_l_f"]) exitwith {
+if (_unitfaction in ["ind_l_f","npr"]) exitwith {
 	#include "f_briefing_npr.sqf"
 	[_unitfaction] call _fnc_debug;
 };
 
 
 // BLUFOR > CTRG
-if (_unitfaction in ["blu_ctrg_f"]) exitwith {
+if (_unitfaction in ["blu_ctrg_f","ctrg"]) exitwith {
 	#include "f_briefing_ctrg.sqf"
 	[_unitfaction] call _fnc_debug;
 };

--- a/f/groupMarkers/f_setLocalGroupMarkers.sqf
+++ b/f/groupMarkers/f_setLocalGroupMarkers.sqf
@@ -52,6 +52,11 @@ if (_unitfaction in ["opf_r_f","spetsnaz"]) then {
 	_groups = f_var_groupData_opfor_spetsnaz;
 };
 
+// Markers seen by players in NPR (Looters) slots.
+if (_unitfaction in ["ind_l_f","npr"]) then {
+	_groups = f_var_groupData_opfor_npr;
+};
+
 // Markers seen by players in AAF slots.
 if (_unitfaction in ["ind_f","aaf"]) then {
 	_groups = f_var_groupData_indfor_aaf;
@@ -75,11 +80,6 @@ if (_unitfaction in ["ind_c_f","syndikat"]) then {
 // Markers seen by players in 3IFB (virtual) slots.
 if (_unitfaction in ["3ifb"]) then {
 	_groups = f_var_groupData_indfor_3ifb;
-};
-
-// Markers seen by players in NPR (Looters) slots.
-if (_unitfaction in ["ind_l_f","npr"]) then {
-	_groups = f_var_groupData_indfor_npr;
 };
 
 // Markers seen by players in Civilian slots.

--- a/f/groupMarkers/f_setLocalGroupMarkers.sqf
+++ b/f/groupMarkers/f_setLocalGroupMarkers.sqf
@@ -23,12 +23,12 @@ params [
 private _groups = [];
 
 // Markers seen by players in NATO, NATO (Pacific) & CTRG slots.
-if (_unitfaction in ["blu_f","blu_t_f","blu_ctrg_f","blu_w_f"]) then {
+if (_unitfaction in ["blu_f","blu_t_f","blu_ctrg_f","blu_w_f","nato","natowoodland","natopacific"]) then {
 	_groups = f_var_groupData_blufor_nato;
 };
 
-// Markers seen by players in FIA & CTRG slots.
-if (_unitfaction in ["blu_g_f","blu_ctrg_f"]) then {
+// Markers seen by players in FIA & CTRG slots. Add "fia" if using "fia" with Virtual Faction.
+if (_unitfaction in ["blu_g_f","blu_ctrg_f","ctrg"]) then {
 	_groups = f_var_groupData_blufor_fia;
 };
 
@@ -38,37 +38,37 @@ if (_unitfaction in ["blu_gen_f"]) then {
 };
 
 // Markers seen by players in CSAT & CSAT (Pacific) slots.
-if (_unitfaction in ["opf_f","opf_t_f"]) then {
+if (_unitfaction in ["opf_f","opf_t_f","csat","csatpacific"]) then {
 	_groups = f_var_groupData_opfor_csat;
 };
 
-// Markers seen by players in OPFOR-FIA slots.
+// Markers seen by players in OPFOR-FIA slots. Add "fia" if using "fia" with Virtual Faction.
 if (_unitfaction in ["opf_g_f"]) then {
 	_groups = f_var_groupData_opfor_fia;
 };
 
 // Markers seen by players in Spetsnaz slots.
-if (_unitfaction in ["opf_r_f"]) then {
+if (_unitfaction in ["opf_r_f","spetsnaz"]) then {
 	_groups = f_var_groupData_opfor_spetsnaz;
 };
 
 // Markers seen by players in AAF slots.
-if (_unitfaction in ["ind_f"]) then {
+if (_unitfaction in ["ind_f","aaf"]) then {
 	_groups = f_var_groupData_indfor_aaf;
 };
 
 // Markers seen by players in LDF slots.
-if (_unitfaction in ["ind_e_f"]) then {
+if (_unitfaction in ["ind_e_f","ldf"]) then {
 	_groups = f_var_groupData_indfor_ldf;
 };
 
-// Markers seen by players in INDEPENDENT-FIA slots.
+// Markers seen by players in INDEPENDENT-FIA slots. Add "fia" if using "fia" with Virtual Faction.
 if (_unitfaction in ["ind_g_f"]) then {
 	_groups = f_var_groupData_indfor_fia;
 };
 
 // Markers seen by players in SYNDIKAT slots.
-if (_unitfaction in ["ind_c_f"]) then {
+if (_unitfaction in ["ind_c_f","syndikat"]) then {
 	_groups = f_var_groupData_indfor_syn;
 };
 
@@ -78,7 +78,7 @@ if (_unitfaction in ["3ifb"]) then {
 };
 
 // Markers seen by players in NPR (Looters) slots.
-if (_unitfaction in ["ind_l_f"]) then {
+if (_unitfaction in ["ind_l_f","npr"]) then {
 	_groups = f_var_groupData_indfor_npr;
 };
 

--- a/f/groupMarkers/f_setLocalGroupMarkers.sqf
+++ b/f/groupMarkers/f_setLocalGroupMarkers.sqf
@@ -22,21 +22,22 @@ params [
 
 private _groups = [];
 
-// Markers seen by players in NATO, NATO (Pacific) & CTRG slots.
+// Markers seen by players in NATO, NATO (Pacific) & NATO (Woodland) slots.
 if (_unitfaction in ["blu_f","blu_t_f","blu_w_f","nato","natowoodland","natopacific"]) then {
 	_groups = f_var_groupData_blufor_nato;
 };
 
-// Markers seen by players in FIA & CTRG slots. Move "fia" to OPFOR FIA or INDFOR FIA if using them.
+// Markers seen by players in FIA slots. Move "fia" to OPFOR FIA or INDFOR FIA if using them.
 if (_unitfaction in ["blu_g_f","fia"]) then {
 	_groups = f_var_groupData_blufor_fia;
 };
 
-// Markers seen by players in gendarmerie slots.
+// Markers seen by players in Gendarmerie slots.
 if (_unitfaction in ["blu_gen_f"]) then {
 	_groups = f_var_groupData_blufor_gen;
 };
 
+// Markers seen by players in CTRG slots.
 if (_unitfaction in ["blu_ctrg_f","ctrg"]) then {
 	_groups = f_var_groupData_blufor_ctrg;
 };

--- a/f/groupMarkers/f_setLocalGroupMarkers.sqf
+++ b/f/groupMarkers/f_setLocalGroupMarkers.sqf
@@ -23,12 +23,12 @@ params [
 private _groups = [];
 
 // Markers seen by players in NATO, NATO (Pacific) & CTRG slots.
-if (_unitfaction in ["blu_f","blu_t_f","blu_ctrg_f","blu_w_f","nato","natowoodland","natopacific"]) then {
+if (_unitfaction in ["blu_f","blu_t_f","blu_w_f","nato","natowoodland","natopacific"]) then {
 	_groups = f_var_groupData_blufor_nato;
 };
 
-// Markers seen by players in FIA & CTRG slots. Add "fia" if using "fia" with Virtual Faction.
-if (_unitfaction in ["blu_g_f","blu_ctrg_f","ctrg"]) then {
+// Markers seen by players in FIA & CTRG slots. Move "fia" to OPFOR FIA or INDFOR FIA if using them.
+if (_unitfaction in ["blu_g_f","fia"]) then {
 	_groups = f_var_groupData_blufor_fia;
 };
 
@@ -37,12 +37,16 @@ if (_unitfaction in ["blu_gen_f"]) then {
 	_groups = f_var_groupData_blufor_gen;
 };
 
+if (_unitfaction in ["blu_ctrg_f","ctrg"]) then {
+	_groups = f_var_groupData_blufor_ctrg;
+};
+
 // Markers seen by players in CSAT & CSAT (Pacific) slots.
 if (_unitfaction in ["opf_f","opf_t_f","csat","csatpacific"]) then {
 	_groups = f_var_groupData_opfor_csat;
 };
 
-// Markers seen by players in OPFOR-FIA slots. Add "fia" if using "fia" with Virtual Faction.
+// Markers seen by players in OPFOR-FIA slots. Add "fia" if using "fia" with Virtual Faction, and remove it from BLUFOR FIA.
 if (_unitfaction in ["opf_g_f"]) then {
 	_groups = f_var_groupData_opfor_fia;
 };
@@ -67,7 +71,7 @@ if (_unitfaction in ["ind_e_f","ldf"]) then {
 	_groups = f_var_groupData_indfor_ldf;
 };
 
-// Markers seen by players in INDEPENDENT-FIA slots. Add "fia" if using "fia" with Virtual Faction.
+// Markers seen by players in INDEPENDENT-FIA slots. Add "fia" if using "fia" with Virtual Faction, and remove it from BLUFOR FIA.
 if (_unitfaction in ["ind_g_f"]) then {
 	_groups = f_var_groupData_indfor_fia;
 };

--- a/f/groupMarkers/fn_groupData.sqf
+++ b/f/groupMarkers/fn_groupData.sqf
@@ -165,6 +165,68 @@ f_var_groupData_blufor_gen = [
 	["GrpGEN_TH1",     _hel, "TH1",    "ColorOrange",  "Gendarmerie TH1 -"]
 ];
 
+f_var_groupData_blufor_ctrg = [
+	["GrpCTRG_CO",     _hq,  "CO",     "ColorYellow",  "CTRG CO -"],
+	["GrpCTRG_DC",     _hq,  "DC",     "ColorYellow",  "CTRG DC -"],
+	["GrpCTRG_COV",    _ifv, "COV",    "ColorYellow",  "CTRG COV -"],
+
+	["GrpCTRG_ASL",    _hq,  "ASL",    "ColorRed",     "CTRG ASL -"],
+	["GrpCTRG_A1",     _ft,  "A1",     "ColorRed",     "CTRG A1 -"],
+	["GrpCTRG_A2",     _ft,  "A2",     "ColorRed",     "CTRG A2 -"],
+	["GrpCTRG_AV",     _ifv, "AV",     "ColorRed",     "CTRG AV -"],
+
+	["GrpCTRG_BSL",    _hq,  "BSL",    "ColorBlue",    "CTRG BSL -"],
+	["GrpCTRG_B1",     _ft,  "B1",     "ColorBlue",    "CTRG B1 -"],
+	["GrpCTRG_B2",     _ft,  "B2",     "ColorBlue",    "CTRG B2 -"],
+	["GrpCTRG_BV",     _ifv, "BV",     "ColorBlue",    "CTRG BV -"],
+
+	["GrpCTRG_CSL",    _hq,  "CSL",    "ColorGreen",   "CTRG CSL -"],
+	["GrpCTRG_C1",     _ft,  "C1",     "ColorGreen",   "CTRG C1 -"],
+	["GrpCTRG_C2",     _ft,  "C2",     "ColorGreen",   "CTRG C2 -"],
+	["GrpCTRG_CV",     _ifv, "CV",     "ColorGreen",   "CTRG CV -"],
+
+	["GrpCTRG_JSL",    _hq,  "JSL",    "ColorPink",    "CTRG JSL -"],
+	["GrpCTRG_J1",     _ft,  "J1",     "ColorPink",    "CTRG J1 -"],
+	["GrpCTRG_J2",     _ft,  "J2",     "ColorPink",    "CTRG J2 -"],
+	["GrpCTRG_JV",     _ifv, "JV",     "ColorPink",    "CTRG JV -"],
+
+	["GrpCTRG_MMG1",   _sup, "MMG1",   "ColorOrange",  "CTRG MMG1 -"],
+	["GrpCTRG_MMG2",   _sup, "MMG2",   "ColorOrange",  "CTRG MMG2 -"],
+	["GrpCTRG_HMG1",   _sup, "HMG1",   "ColorOrange",  "CTRG HMG1 -"],
+	["GrpCTRG_MAT1",   _lau, "MAT1",   "ColorOrange",  "CTRG MAT1 -"],
+	["GrpCTRG_MAT2",   _lau, "MAT2",   "ColorOrange",  "CTRG MAT2 -"],
+	["GrpCTRG_HAT1",   _lau, "HAT1",   "ColorOrange",  "CTRG HAT1 -"],
+	["GrpCTRG_MTR1",   _mor, "MTR1",   "ColorOrange",  "CTRG MTR1 -"],
+	["GrpCTRG_MSAM1",  _lau, "MSAM1",  "ColorOrange",  "CTRG MSAM1 -"],
+	["GrpCTRG_HSAM1",  _lau, "HSAM1",  "ColorOrange",  "CTRG HSAM1 -"],
+	["GrpCTRG_ST1",    _rec, "ST1",    "ColorOrange",  "CTRG ST1 -"],
+	["GrpCTRG_DT1",    _rec, "DT1",    "ColorOrange",  "CTRG DT1 -"],
+	["GrpCTRG_ENG1",   _eng, "ENG1",   "ColorOrange",  "CTRG ENG1 -"],
+
+	["GrpCTRG_IFV1",   _ifv, "IFV1",   "ColorOrange",  "CTRG IFV1 -"],
+	["GrpCTRG_IFV2",   _ifv, "IFV2",   "ColorOrange",  "CTRG IFV2 -"],
+	["GrpCTRG_TNK1",   _tnk, "TNK1",   "ColorRed",     "CTRG TNK1 -"],
+
+	["GrpCTRG_CAS1",   _pla, "CAS1",   "ColorOrange",  "CTRG CAS1 -"],
+
+	["GrpCTRG_TH1",    _hel, "TH1",    "ColorRed",     "CTRG TH1 -"],
+	["GrpCTRG_TH2",    _hel, "TH2",    "ColorRed",     "CTRG TH2 -"],
+	["GrpCTRG_TH3",    _hel, "TH3",    "ColorBlue",    "CTRG TH3 -"],
+	["GrpCTRG_TH4",    _hel, "TH4",    "ColorBlue",    "CTRG TH4 -"],
+	["GrpCTRG_TH5",    _hel, "TH5",    "ColorGreen",   "CTRG TH5 -"],
+	["GrpCTRG_TH6",    _hel, "TH6",    "ColorGreen",   "CTRG TH6 -"],
+	["GrpCTRG_TH7",    _hel, "TH7",    "ColorOrange",  "CTRG TH7 -"],
+	["GrpCTRG_TH8",    _hel, "TH8",    "ColorOrange",  "CTRG TH8 -"],
+
+	["GrpCTRG_AH1",    _hel, "AH1",    "ColorRed",     "CTRG AH1 -"],
+
+	["UnitCTRG_CO_M",  _med, "COM",    "ColorBlack",   ""],
+	["UnitCTRG_DC_M",  _med, "DCM",    "ColorBlack",   ""],
+	["UnitCTRG_ASL_M", _med, "AM",     "ColorBlack",   ""],
+	["UnitCTRG_BSL_M", _med, "BM",     "ColorBlack",   ""],
+	["UnitCTRG_CSL_M", _med, "CM",     "ColorBlack",   ""]
+];
+
 f_var_groupData_opfor_csat = [
 	["GrpCSAT_CO",     _hq,  "CO",     "ColorYellow",  "CSAT CO -"],
 	["GrpCSAT_DC",     _hq,  "DC",     "ColorYellow",  "CSAT DC -"],
@@ -730,6 +792,7 @@ f_var_groupData_all = [];
 f_var_groupData_all append f_var_groupData_blufor_nato;
 f_var_groupData_all append f_var_groupData_blufor_fia;
 f_var_groupData_all append f_var_groupData_blufor_gen;
+f_var_groupData_all append f_var_groupData_blufor_ctrg;
 f_var_groupData_all append f_var_groupData_opfor_csat;
 f_var_groupData_all append f_var_groupData_opfor_fia;
 f_var_groupData_all append f_var_groupData_opfor_spetsnaz;

--- a/f/groupMarkers/fn_groupData.sqf
+++ b/f/groupMarkers/fn_groupData.sqf
@@ -657,7 +657,7 @@ f_var_groupData_indfor_LDF = [
 	["UnitLDF_CSL_M", _med, "CM",     "ColorBlack",   ""]
 ];
 
-f_var_groupData_indfor_npr = [
+f_var_groupData_opfor_npr = [
 	["GrpNPR_CO",     _hq,  "CO",     "ColorYellow",  "NPR CO -"],
 	["GrpNPR_DC",     _hq,  "DC",     "ColorYellow",  "NPR DC -"],
 	["GrpNPR_COV",    _ifv, "COV",    "ColorYellow",  "NPR COV -"],
@@ -733,12 +733,12 @@ f_var_groupData_all append f_var_groupData_blufor_gen;
 f_var_groupData_all append f_var_groupData_opfor_csat;
 f_var_groupData_all append f_var_groupData_opfor_fia;
 f_var_groupData_all append f_var_groupData_opfor_spetsnaz;
+f_var_groupData_all append f_var_groupData_opfor_npr;
 f_var_groupData_all append f_var_groupData_indfor_aaf;
 f_var_groupData_all append f_var_groupData_indfor_fia;
 f_var_groupData_all append f_var_groupData_indfor_syn;
 f_var_groupData_all append f_var_groupData_indfor_3ifb;
 f_var_groupData_all append f_var_groupData_indfor_ldf;
-f_var_groupData_all append f_var_groupData_indfor_npr;
 f_var_groupData_all append f_var_groupData_civ;
 
 // ====================================================================================


### PR DESCRIPTION
assignGear accepts some faction aliases for use with Virtual Faction such as "aaf" for "ind_f". This PR adds those aliases to other components to better accommodate new VF-only factions, specifically NPR.

Also updates groupMarkers to reflect than NPR will be OPFOR in the template.

Components affected: groupData, assignInsignia, briefing