### PR TITLE
i280 - f_fnc_setWeather rain fog

### DIFF
--- a/f/missionConditions/fn_SetWeather.sqf
+++ b/f/missionConditions/fn_SetWeather.sqf
@@ -122,7 +122,7 @@ switch (_weather) do
 		_MissionWindGusts = 0.2;
 		_MissionWaves = 0.5;
 		_MissionFogStrength = 0.03;
-		_MissionFogDecay = 0;
+		_MissionFogDecay = 0.002;
 		_MissionFogBase = 0;
 	};
 // Light Rain
@@ -135,8 +135,8 @@ switch (_weather) do
 		_MissionWindStr = 0.25;
 		_MissionWindGusts = 0.25;
 		_MissionWaves = 0.5;
-		_MissionFogStrength = 0.07;
-		_MissionFogDecay = 0;
+		_MissionFogStrength = 0.04;
+		_MissionFogDecay = 0.002;
 		_MissionFogBase = 0;
 	};
 // Heavy Rain
@@ -149,8 +149,8 @@ switch (_weather) do
 		_MissionWindStr = 0.4;
 		_MissionWindGusts = 0.4;
 		_MissionWaves = 0.8;
-		_MissionFogStrength = 0.15;
-		_MissionFogDecay = 0;
+		_MissionFogStrength = 0.04;
+		_MissionFogDecay = 0.002;
 		_MissionFogBase = 0;
 	};
 // Storm
@@ -163,8 +163,8 @@ switch (_weather) do
 		_MissionWindStr = 0.75;
 		_MissionWindGusts = 1;
 		_MissionWaves = 1;
-		_MissionFogStrength = 0.3;
-		_MissionFogDecay = 0;
+		_MissionFogStrength = 0.05;
+		_MissionFogDecay = 0.002;
 		_MissionFogBase = 0;
 	};
 };


### PR DESCRIPTION
#280

After some playing around I ended up dialing down the fog a lot for all rain weather settings. The main problem is that fog tends to wash out dark colors without affecting the actual light levels, which makes stormy scenes look much brighter than it should (the fact that Arma doesn't really do dark clouds very well to begin with doesn't help).

All weather settings were tested at sea level and at the highest point on Malden, which is the highest point I could find in BI maps.

The old stormy:
![20200128101119_1](https://user-images.githubusercontent.com/11525430/73281219-9ef98b00-41bd-11ea-902f-5da8dea7ee2a.jpg)
The new stormy:
![20200128101134_1](https://user-images.githubusercontent.com/11525430/73281200-9903aa00-41bd-11ea-8918-a2851960a208.jpg)
An in-between. Note the lower contrast between the dark and light parts of the cloud; I don't think it really comes through in this screenshot but in game it makes the scene look a lot brighter overall, too bright for a storm.
![20200128101150_1](https://user-images.githubusercontent.com/11525430/73281230-a0c34e80-41bd-11ea-9909-eb6f1b0cdab6.jpg)


