### PR TITLE
Fixes for 293 282 and 292

### DIFF
--- a/f/assignGear/f_assignGear_ldf.sqf
+++ b/f/assignGear/f_assignGear_ldf.sqf
@@ -200,8 +200,8 @@ _bagRadio = "B_RadioBag_01_eaf_F";			// cosmetic, used by COs, DCs, and anybody 
 
 // Automatic Rifleman
 _AR = "LMG_Mk200_black_F";
-_ARmag = "200Rnd_65x39_cased_Box";
-_ARmag_tr = "200Rnd_65x39_cased_Box_Tracer";
+_ARmag = "200Rnd_65x39_cased_Box_Red";
+_ARmag_tr = "200Rnd_65x39_cased_Box_Tracer_Red";
 
 // Medium MG
 _MMG = "MMG_02_black_F";

--- a/f/assignGear/f_assignGear_syndikat.sqf
+++ b/f/assignGear/f_assignGear_syndikat.sqf
@@ -290,7 +290,7 @@ _crewRig = ["V_Chestrig_blk"];
 _crewGlasses = [];
 
 // Ghillie
-_ghillieUniform = ["U_B_GhillieSuit"];	//DLC alternatives: ["U_B_FullGhillie_lsh","U_B_FullGhillie_ard","U_B_FullGhillie_sard"];
+_ghillieUniform = ["U_B_T_Sniper_F"];	//DLC alternatives: ["U_B_FullGhillie_lsh","U_B_FullGhillie_ard","U_B_FullGhillie_sard"]; CSAT option: ["U_O_T_Sniper_F"];, ["U_O_T_FullGhillie_tna_F"];
 _ghillieHelmet = [];
 _ghillieRig = ["V_Chestrig_rgr"];
 _ghillieGlasses = [];

--- a/f/groupMarkers/fn_groupData.sqf
+++ b/f/groupMarkers/fn_groupData.sqf
@@ -757,8 +757,8 @@ f_var_groupData_opfor_npr = [
 	["GrpNPR_DT1",    _rec, "DT1",    "ColorOrange",  "NPR DT1 -"],
 	["GrpNPR_ENG1",   _eng, "ENG1",   "ColorOrange",  "NPR ENG1 -"],
 
-	["GrpNPR_IFV1",   _ifv, "IFV1",   "ColorOrange",  "NPR IFV1 -"],
-	["GrpNPR_IFV2",   _ifv, "IFV2",   "ColorOrange",  "NPR IFV2 -"],
+	["GrpNPR_IFV1",   _ifv, "TECH1",   "ColorOrange",  "NPR TECH1 -"],
+	["GrpNPR_IFV2",   _ifv, "TECH2",   "ColorOrange",  "NPR TECH2 -"],
 	["GrpNPR_TNK1",   _tnk, "TNK1",   "ColorRed",     "NPR TNK1 -"],
 
 	["GrpNPR_CAS1",   _pla, "CAS1",   "ColorOrange",  "NPR CAS1 -"],


### PR DESCRIPTION
Fixes issue #292 by changing LDF AR mags to red.

Fixes issue #293 by changing NPR "IFV" group data to "TECH" in parity with FIA, etc.

Fixes issue #282 by changing the NATO Mediterranean ghillie to its equivalent NATO Pacific ghillie.