### PR TITLE
296 AI skill changes

### DIFF
--- a/description.ext
+++ b/description.ext
@@ -220,7 +220,7 @@ class Params
 		title = "$STR_f_param_AISkill_BLUFOR";
 		values[] = {0,1,2,3};
 		texts[] = {$STR_f_param_AISkill_Option0,$STR_f_param_AISkill_Option1,$STR_f_param_AISkill_Option2,$STR_f_param_AISkill_Option3};
-		default = 1;
+		default = 2;
 	};
 
 	class f_param_AISkill_OPFOR
@@ -228,7 +228,7 @@ class Params
 		title = "$STR_f_param_AISkill_OPFOR";
 		values[] = {0,1,2,3};
 		texts[] = {$STR_f_param_AISkill_Option0,$STR_f_param_AISkill_Option1,$STR_f_param_AISkill_Option2,$STR_f_param_AISkill_Option3};
-		default = 1;
+		default = 2;
 	};
 
 	class f_param_AISkill_INDP
@@ -236,7 +236,7 @@ class Params
 		title = "$STR_f_param_AISkill_INDP";
 		values[] = {0,1,2,3};
 		texts[] = {$STR_f_param_AISkill_Option0,$STR_f_param_AISkill_Option1,$STR_f_param_AISkill_Option2,$STR_f_param_AISkill_Option3};
-		default = 1;
+		default = 2;
 	};
 
 // ============================================================================================

--- a/f/setAISkill/f_setAISkill.sqf
+++ b/f/setAISkill/f_setAISkill.sqf
@@ -50,10 +50,10 @@ private _skillLevels = [
 //       then this means that this particular skill will always be 1
 //       for all possible skillLevels that were set via parameter.
 f_var_skillSet = [
-	0.55, // aimingAccuracy
-	0.6,  // aimingShake
-	0.6,  // aimingSpeed
-	0.7,  // spotDistance
+	0.45, // aimingAccuracy
+	0.5,  // aimingShake
+	0.5,  // aimingSpeed
+	0.65,  // spotDistance
 	0.7,  // spotTime
 	1.2,  // courage
 	2,    // reloadSpeed


### PR DESCRIPTION
This PR addresses #296 by changing the default AI skill parameter to Medium (from High). It also adjusts the base skill values to reduce AI accuracy, which should make the parameter values better calibrated for LAMBS Danger rather than forcing us to only ever use Low.