### PR TITLE
301 CSAT tac vests

### DIFF
--- a/f/groupMarkers/fn_groupData.sqf
+++ b/f/groupMarkers/fn_groupData.sqf
@@ -571,8 +571,8 @@ f_var_groupData_indfor_syn = [
 	["GrpSyn_DT1",     _rec, "DT1",    "ColorOrange",  "Syndikat DT1 -"],
 	["GrpSyn_ENG1",    _eng, "ENG1",   "ColorOrange",  "Syndikat ENG1 -"],
 
-	["GrpSyn_IFV1",    _ifv, "TECH1",  "ColorRed",     "Syndikat IFV1 -"],
-	["GrpSyn_IFV2",    _ifv, "TECH2",  "ColorRed",     "Syndikat IFV2 -"],
+	["GrpSyn_IFV1",    _ifv, "TECH1",  "ColorRed",     "Syndikat TECH1 -"],
+	["GrpSyn_IFV2",    _ifv, "TECH2",  "ColorRed",     "Syndikat TECH2 -"],
 	["GrpSyn_TNK1",    _tnk, "TNK1",   "ColorRed",     "Syndikat TNK1 -"],
 
 	["GrpSyn_CAS1",    _pla, "CAS1",   "ColorOrange",  "Syndikat CAS1 -"],

--- a/mission.sqm
+++ b/mission.sqm
@@ -5,29 +5,44 @@ class EditorData
 	angleGridStep=0.2617994;
 	scaleGridStep=1;
 	autoGroupingDist=10;
-	toggles=513;
+	toggles=517;
 	class ItemIDProvider
 	{
-		nextID=1656;
+		nextID=3706;
 	};
 	class Camera
 	{
-		pos[]={1465.2286,112.83681,885.57111};
-		dir[]={-0.012939595,-0.69021803,0.72348863};
-		up[]={-0.012342638,0.72360009,0.69011098};
-		aside[]={0.99984413,-4.4892658e-009,0.017882211};
+		pos[]={2521.6931,34.724888,919.46991};
+		dir[]={-0.76816863,-0.33065769,0.54826856};
+		up[]={-0.26914039,0.94374913,0.19209684};
+		aside[]={0.58094877,1.6466947e-007,0.81395072};
 	};
 };
 binarizationWanted=0;
 addons[]=
 {
+	"A3_Soft_F_Enoch_Truck_02",
+	"A3_Soft_F_Enoch_Offroad_01",
+	"A3_Modules_F_Supports",
+	"A3_Characters_F_Enoch",
+	"A3_Air_F_Enoch_Heli_Light_03",
+	"A3_Modules_F",
+	"A3_Static_F_Enoch_Mortar_01",
+	"A3_Supplies_F_Enoch_Ammoboxes",
+	"A3_Armor_F_Enoch_APC_Tracked_03",
+	"A3_Weapons_F_Ammoboxes",
+	"A3_Characters_F",
+	"A3_Soft_F_Offroad_01",
+	"A3_Soft_F_Gamma_Van_01",
+	"A3_Air_F_Heli_Light_02",
+	"A3_Static_F_Mortar_01",
+	"A3_Air_F_Heli_Light_01",
 	"A3_Air_F_Heli_Heli_Transport_03",
 	"A3_Air_F_Heli_Heli_Transport_04",
 	"A3_Air_F_Beta_Heli_Transport_02",
 	"A3_Air_F_Beta_Heli_Transport_01",
 	"A3_Armor_F_Beta_APC_Tracked_01",
 	"A3_Air_F_Beta_Heli_Attack_01",
-	"A3_Air_F_Heli_Light_02",
 	"A3_Armor_F_Beta_APC_Wheeled_02",
 	"A3_Air_F_Beta_Heli_Attack_02",
 	"A3_Armor_F_EPC_MBT_01",
@@ -41,24 +56,16 @@ addons[]=
 	"A3_Soft_F_Beta_Truck_01",
 	"A3_Soft_F_Exp_Truck_01",
 	"A3_Soft_F_MRAP_02",
-	"A3_Soft_F_Offroad_01",
-	"A3_Soft_F_Gamma_Van_01",
-	"A3_Weapons_F_Ammoboxes",
-	"A3_Air_F_Heli_Light_01",
 	"A3_Armor_F_Beta_APC_Wheeled_01",
 	"A3_Armor_F_Beta_APC_Tracked_02",
 	"A3_Armor_F_EPB_APC_Tracked_03",
 	"A3_Modules_F_Curator_Curator",
-	"A3_Modules_F_Supports",
-	"A3_Characters_F",
-	"A3_Static_F_Mortar_01",
 	"A3_Data_F_Curator_Virtual",
 	"A3_Characters_F_Exp",
 	"A3_Soft_F_Exp_Offroad_02",
 	"A3_Soft_F_Exp_Van_01",
 	"A3_Soft_F_Exp_Offroad_01",
 	"A3_Soft_F_Gamma_SUV_01",
-	"A3_Modules_F",
 	"A3_Data_F_Exp_A_Virtual",
 	"A3_Air_F_EPC_Plane_CAS_01",
 	"A3_Characters_F_Jets",
@@ -70,67 +77,67 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=24;
+		items=30;
 		class Item0
 		{
-			className="A3_Air_F_Heli";
-			name="Arma 3 Helicopters - Aircraft";
+			className="A3_Soft_F_Enoch";
+			name="Arma 3 Enoch - Unarmored Land Vehicles";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
 		class Item1
 		{
-			className="A3_Air_F_Beta";
-			name="Arma 3 Beta - Aircraft";
+			className="A3_Modules_F";
+			name="Arma 3 Alpha - Scripted Modules";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
 		class Item2
 		{
-			className="A3_Armor_F_Beta";
-			name="Arma 3 Beta - Armored Land Vehicles";
+			className="A3_Characters_F_Enoch";
+			name="Arma 3 Enoch - Characters and Clothing";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
 		class Item3
 		{
-			className="A3_Air_F";
-			name="Arma 3 Alpha - Aircraft";
+			className="A3_Air_F_Enoch";
+			name="Arma 3 Enoch - Aircraft";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
 		class Item4
 		{
-			className="A3_Armor_F_EPC";
-			name="Arma 3 Win Episode - Armored Land Vehicles";
+			className="A3_Static_F_Enoch";
+			name="Arma 3 Enoch - Turrets";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
 		class Item5
 		{
-			className="A3_Armor_F_Gamma";
-			name="Arma 3 - Armored Land Vehicles";
+			className="A3_Supplies_F_Enoch";
+			name="Arma 3 Enoch - Ammoboxes and Supplies";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
 		class Item6
 		{
-			className="A3_Armor_F_EPB";
-			name="Arma 3 Adapt Episode - Armored Land Vehicles";
+			className="A3_Armor_F_Enoch";
+			name="CFGPATCHES_A3_Armor_F_Enoch";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
 		class Item7
 		{
-			className="A3_Air_F_EPB";
-			name="Arma 3 Adapt Episode - Aircraft";
+			className="A3_Weapons_F";
+			name="Arma 3 Alpha - Weapons and Accessories";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
 		class Item8
 		{
-			className="A3_Soft_F_Beta";
-			name="Arma 3 Beta - Unarmored Land Vehicles";
+			className="A3_Characters_F";
+			name="Arma 3 Alpha - Characters and Clothing";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
@@ -143,96 +150,138 @@ class AddonsMetaData
 		};
 		class Item10
 		{
-			className="A3_Soft_F_Exp";
-			name="Arma 3 Apex - Unarmored Land Vehicles";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item11
-		{
 			className="A3_Soft_F_Gamma";
 			name="Arma 3 - Unarmored Land Vehicles";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
+		class Item11
+		{
+			className="A3_Air_F";
+			name="Arma 3 Alpha - Aircraft";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
 		class Item12
-		{
-			className="A3_Weapons_F";
-			name="Arma 3 Alpha - Weapons and Accessories";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item13
-		{
-			className="A3_Modules_F_Curator";
-			name="Arma 3 Zeus Update - Scripted Modules";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item14
-		{
-			className="A3_Modules_F";
-			name="Arma 3 Alpha - Scripted Modules";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item15
-		{
-			className="A3_Characters_F";
-			name="Arma 3 Alpha - Characters and Clothing";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item16
 		{
 			className="A3_Static_F";
 			name="Arma 3 Alpha - Turrets";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
+		class Item13
+		{
+			className="A3_Air_F_Heli";
+			name="Arma 3 Helicopters - Aircraft";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item14
+		{
+			className="A3_Air_F_Beta";
+			name="Arma 3 Beta - Aircraft";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item15
+		{
+			className="A3_Armor_F_Beta";
+			name="Arma 3 Beta - Armored Land Vehicles";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item16
+		{
+			className="A3_Armor_F_EPC";
+			name="Arma 3 Win Episode - Armored Land Vehicles";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
 		class Item17
+		{
+			className="A3_Armor_F_Gamma";
+			name="Arma 3 - Armored Land Vehicles";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item18
+		{
+			className="A3_Armor_F_EPB";
+			name="Arma 3 Adapt Episode - Armored Land Vehicles";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item19
+		{
+			className="A3_Air_F_EPB";
+			name="Arma 3 Adapt Episode - Aircraft";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item20
+		{
+			className="A3_Soft_F_Beta";
+			name="Arma 3 Beta - Unarmored Land Vehicles";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item21
+		{
+			className="A3_Soft_F_Exp";
+			name="Arma 3 Apex - Unarmored Land Vehicles";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item22
+		{
+			className="A3_Modules_F_Curator";
+			name="Arma 3 Zeus Update - Scripted Modules";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item23
 		{
 			className="A3_Data_F_Curator";
 			name="Arma 3 Zeus Update - Main Configuration";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item18
+		class Item24
 		{
 			className="A3_Characters_F_Exp";
 			name="Arma 3 Apex - Characters and Clothing";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item19
+		class Item25
 		{
 			className="A3_Data_F_Exp_A";
 			name="Arma 3 Nexus Update - Main Configuration";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item20
+		class Item26
 		{
 			className="A3_Air_F_EPC";
 			name="Arma 3 Win Episode - Aircraft";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item21
+		class Item27
 		{
 			className="A3_Characters_F_Jets";
 			name="Arma 3 Jets - Characters and Clothing";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item22
+		class Item28
 		{
 			className="A3_Air_F_Gamma";
 			name="Arma 3 - Aircraft";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item23
+		class Item29
 		{
 			className="A3_Soft_F_Bootcamp";
 			name="Arma 3 Bootcamp Update - Unarmored Land Vehicles";
@@ -280,7 +329,7 @@ class Mission
 {
 	class Intel
 	{
-		briefingName="fa3-5-3";
+		briefingName="fa3-5-4";
 		resistanceWest=0;
 		timeOfChanges=28800;
 		startWeather=0.50001526;
@@ -304,13 +353,11051 @@ class Mission
 	};
 	class Entities
 	{
-		items=460;
+		items=593;
 		class Item0
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={432.07535,8.3443718,1248.3243};
+				position[]={1414.5186,7.3817577,571.53052};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""v_tr"",this] call f_fnc_assignGear";
+				name="VehLDF_TR1";
+			};
+			id=2053;
+			type="I_E_Truck_02_transport_F";
+		};
+		class Item1
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1459.9346,7.3817577,571.48462};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""v_tr"",this] call f_fnc_assignGear";
+				name="VehLDF_TR2";
+			};
+			id=2054;
+			type="I_E_Truck_02_transport_F";
+		};
+		class Item2
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1502.0322,7.3817577,571.65845};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""v_tr"",this] call f_fnc_assignGear";
+				name="VehLDF_TR3";
+			};
+			id=2055;
+			type="I_E_Truck_02_transport_F";
+		};
+		class Item3
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1364.127,6.8319178,557.20605};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""v_car"",this] call f_fnc_assignGear";
+				name="VehLDF_CAR1";
+				reportRemoteTargets=1;
+			};
+			id=2056;
+			type="I_E_Offroad_01_comms_F";
+			atlOffset=0.11480904;
+		};
+		class Item4
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1364.3169,6.8319178,527.73975};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""v_car"",this] call f_fnc_assignGear";
+				name="VehLDF_CAR2";
+				reportRemoteTargets=1;
+			};
+			id=2057;
+			type="I_E_Offroad_01_comms_F";
+			atlOffset=0.11480904;
+		};
+		class Item5
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1347.4922,5,555.66821};
+			};
+			id=2073;
+			type="SupportRequester";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="SupportRequester_BIS_SUPP_limit_UAV";
+					expression="_this setVariable ['BIS_SUPP_limit_UAV',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="SupportRequester_BIS_SUPP_custom_HQ";
+					expression="_this setVariable ['BIS_SUPP_custom_HQ',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="SupportRequester_BIS_SUPP_limit_Transport";
+					expression="_this setVariable ['BIS_SUPP_limit_Transport',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				class Attribute3
+				{
+					property="SupportRequester_BIS_SUPP_limit_Drop";
+					expression="_this setVariable ['BIS_SUPP_limit_Drop',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				class Attribute4
+				{
+					property="SupportRequester_BIS_SUPP_limit_CAS_Heli";
+					expression="_this setVariable ['BIS_SUPP_limit_CAS_Heli',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				class Attribute5
+				{
+					property="SupportRequester_BIS_SUPP_limit_Artillery";
+					expression="_this setVariable ['BIS_SUPP_limit_Artillery',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				class Attribute6
+				{
+					property="SupportRequester_BIS_SUPP_limit_CAS_Bombing";
+					expression="_this setVariable ['BIS_SUPP_limit_CAS_Bombing',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				nAttributes=7;
+			};
+		};
+		class Item6
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1349.4941,5.0014391,549.57861};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+					};
+					id=2075;
+					type="I_E_Helipilot_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1349.4941,5.0014391,549.57861};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+					};
+					id=2076;
+					type="I_E_Helipilot_F";
+				};
+			};
+			class Attributes
+			{
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=2;
+				};
+				class Links
+				{
+					items=2;
+					class Item0
+					{
+						linkID=0;
+						item0=2075;
+						item1=2077;
+						class CustomData
+						{
+							role=1;
+						};
+					};
+					class Item1
+					{
+						linkID=1;
+						item0=2076;
+						item1=2077;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+				};
+			};
+			id=2074;
+		};
+		class Item7
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1349.4941,6.5310755,549.52856};
+			};
+			side="Independent";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+				receiveRemoteTargets=1;
+			};
+			id=2077;
+			type="I_E_Heli_light_03_dynamicLoadout_F";
+		};
+		class Item8
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=1;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1345.3809,5.0014391,549.59961};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+					};
+					id=2367;
+					type="I_E_Soldier_F";
+				};
+			};
+			class Attributes
+			{
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=1;
+				};
+				class Links
+				{
+					items=1;
+					class Item0
+					{
+						linkID=0;
+						item0=2367;
+						item1=2366;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+				};
+			};
+			id=2078;
+		};
+		class Item9
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1347.9287,5,525.74048};
+			};
+			id=2081;
+			type="SupportRequester";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="SupportRequester_BIS_SUPP_limit_UAV";
+					expression="_this setVariable ['BIS_SUPP_limit_UAV',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="SupportRequester_BIS_SUPP_custom_HQ";
+					expression="_this setVariable ['BIS_SUPP_custom_HQ',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="SupportRequester_BIS_SUPP_limit_Transport";
+					expression="_this setVariable ['BIS_SUPP_limit_Transport',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				class Attribute3
+				{
+					property="SupportRequester_BIS_SUPP_limit_Drop";
+					expression="_this setVariable ['BIS_SUPP_limit_Drop',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				class Attribute4
+				{
+					property="SupportRequester_BIS_SUPP_limit_CAS_Heli";
+					expression="_this setVariable ['BIS_SUPP_limit_CAS_Heli',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				class Attribute5
+				{
+					property="SupportRequester_BIS_SUPP_limit_Artillery";
+					expression="_this setVariable ['BIS_SUPP_limit_Artillery',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				class Attribute6
+				{
+					property="SupportRequester_BIS_SUPP_limit_CAS_Bombing";
+					expression="_this setVariable ['BIS_SUPP_limit_CAS_Bombing',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				nAttributes=7;
+			};
+		};
+		class Item10
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1350.0137,5.0014391,519.70459};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+					};
+					id=2083;
+					type="I_E_Helipilot_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1350.0137,5.0014391,519.70459};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+					};
+					id=2084;
+					type="I_E_Helipilot_F";
+				};
+			};
+			class Attributes
+			{
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=2;
+				};
+				class Links
+				{
+					items=2;
+					class Item0
+					{
+						linkID=0;
+						item0=2083;
+						item1=2085;
+						class CustomData
+						{
+							role=1;
+						};
+					};
+					class Item1
+					{
+						linkID=1;
+						item0=2084;
+						item1=2085;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+				};
+			};
+			id=2082;
+		};
+		class Item11
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1350.0137,6.5310755,519.65454};
+			};
+			side="Independent";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+				receiveRemoteTargets=1;
+			};
+			id=2085;
+			type="I_E_Heli_light_03_dynamicLoadout_F";
+		};
+		class Item12
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=1;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1345.855,5.0014391,519.698};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+					};
+					id=2369;
+					type="I_E_Soldier_F";
+				};
+			};
+			class Attributes
+			{
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=1;
+				};
+				class Links
+				{
+					items=1;
+					class Item0
+					{
+						linkID=0;
+						item0=2369;
+						item1=2368;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+				};
+			};
+			id=2086;
+		};
+		class Item13
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1349.6787,5,553.24731};
+			};
+			id=2196;
+			type="SupportProvider_Virtual_CAS_Heli";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_cooldown";
+					expression="_this setVariable ['BIS_SUPP_cooldown',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"SCALAR"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicleInit";
+					expression="_this setVariable ['BIS_SUPP_vehicleInit',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicles";
+					expression="_this setVariable ['BIS_SUPP_vehicles',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[]";
+						};
+					};
+				};
+				class Attribute3
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_filter";
+					expression="_this setVariable ['BIS_SUPP_filter',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Side";
+						};
+					};
+				};
+				nAttributes=4;
+			};
+		};
+		class Item14
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1350.1152,5,523.32056};
+			};
+			id=2197;
+			type="SupportProvider_Virtual_CAS_Heli";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_cooldown";
+					expression="_this setVariable ['BIS_SUPP_cooldown',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"SCALAR"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicleInit";
+					expression="_this setVariable ['BIS_SUPP_vehicleInit',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicles";
+					expression="_this setVariable ['BIS_SUPP_vehicles',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[]";
+						};
+					};
+				};
+				class Attribute3
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_filter";
+					expression="_this setVariable ['BIS_SUPP_filter',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Side";
+						};
+					};
+				};
+				nAttributes=4;
+			};
+		};
+		class Item15
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1345.834,5,523.41724};
+			};
+			id=2198;
+			type="SupportProvider_Artillery";
+		};
+		class Item16
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1345.3975,5,553.34399};
+			};
+			id=2199;
+			type="SupportProvider_Artillery";
+		};
+		class Item17
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1404.6733,5,580.39526};
+			};
+			name="F3_preMount_LDF";
+			init="[synchronizedObjects this, [""GrpLDF_ASL"",""GrpLDF_A1"",""GrpLDF_A2""], true, false] call f_fnc_mountGroups;";
+			id=2200;
+			type="Logic";
+		};
+		class Item18
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1448.5806,5,582.0376};
+			};
+			name="F3_preMount_LDF_1";
+			init="[synchronizedObjects this, [""GrpLDF_BSL"",""GrpLDF_B1"",""GrpLDF_B2""], true, false] call f_fnc_mountGroups;;";
+			id=2201;
+			type="Logic";
+		};
+		class Item19
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1491.5488,5,581.80518};
+			};
+			name="F3_preMount_LDF_2";
+			init="[synchronizedObjects this, [""GrpLDF_CSL"",""GrpLDF_C1"",""GrpLDF_C2""], true, false] call f_fnc_mountGroups;";
+			id=2202;
+			type="Logic";
+		};
+		class Item20
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1361.9395,5,574.99536};
+			};
+			name="F3_preMount_LDF_3";
+			init="[synchronizedObjects this, [""GrpLDF_CO""], true, false] call f_fnc_mountGroups;";
+			id=2203;
+			type="Logic";
+		};
+		class Item21
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1360.7656,5,546.81909};
+			};
+			name="F3_preMount_LDF_4";
+			init="[synchronizedObjects this, [""GrpLDF_DC""], true, false] call f_fnc_mountGroups;";
+			id=2204;
+			type="Logic";
+		};
+		class Item22
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1575.2297,6.8321085,546.9436};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""v_car"",this] call f_fnc_assignGear";
+				name="VehLDF_CAR3";
+				reportRemoteTargets=1;
+			};
+			id=2362;
+			type="I_E_Offroad_01_covered_F";
+			atlOffset=0.11499977;
+		};
+		class Item23
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1576.6787,6.8321085,519.27856};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""v_car"",this] call f_fnc_assignGear";
+				name="VehLDF_CAR4";
+				reportRemoteTargets=1;
+			};
+			id=2363;
+			type="I_E_Offroad_01_covered_F";
+			atlOffset=0.11499977;
+		};
+		class Item24
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1345.3809,5.7216258,549.54932};
+			};
+			side="Independent";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+			};
+			id=2366;
+			type="I_E_Mortar_01_F";
+		};
+		class Item25
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1345.855,5.7216258,519.64764};
+			};
+			side="Independent";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+			};
+			id=2368;
+			type="I_E_Mortar_01_F";
+		};
+		class Item26
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1419.1116,5.8924227,562.052};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""crate_med"",this,""ind_e_f""] call f_fnc_assignGear";
+				name="CrateLDF_A";
+			};
+			id=2371;
+			type="I_EAF_supplyCrate_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="ammoBox";
+					expression="[_this,_value] call bis_fnc_initAmmoBox;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[[[[""launch_RPG32_F"",""arifle_TRG20_F"",""arifle_TRG21_F"",""arifle_TRG21_GL_F"",""srifle_DMR_06_camo_F"",""srifle_DMR_06_olive_F"",""LMG_Mk200_F""],[1,1,4,1,1,1,2]],[[""30Rnd_556x45_Stanag"",""200Rnd_65x39_cased_Box"",""20Rnd_762x51_Mag"",""1Rnd_HE_Grenade_shell"",""1Rnd_Smoke_Grenade_shell"",""1Rnd_SmokeGreen_Grenade_shell"",""Chemlight_blue"",""RPG32_F"",""RPG32_HE_F"",""HandGrenade"",""MiniGrenade"",""SmokeShell"",""SmokeShellGreen"",""UGL_FlareWhite_F"",""UGL_FlareGreen_F""],[24,6,12,6,2,2,6,3,1,6,6,2,2,2,2]],[[""Binocular"",""Rangefinder"",""FirstAidKit"",""acc_flashlight"",""bipod_03_F_oli"",""V_Chestrig_oli"",""V_TacVest_blk""],[1,1,10,2,2,4,4]],[[""B_TacticalPack_blk""],[2]]],false]";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item27
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1463.3728,5.8924227,563.448};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""crate_med"",this,""ind_e_f""] call f_fnc_assignGear";
+				name="CrateLDF_B";
+			};
+			id=2372;
+			type="I_EAF_supplyCrate_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="ammoBox";
+					expression="[_this,_value] call bis_fnc_initAmmoBox;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[[[[""launch_RPG32_F"",""arifle_TRG20_F"",""arifle_TRG21_F"",""arifle_TRG21_GL_F"",""srifle_DMR_06_camo_F"",""srifle_DMR_06_olive_F"",""LMG_Mk200_F""],[1,1,4,1,1,1,2]],[[""30Rnd_556x45_Stanag"",""200Rnd_65x39_cased_Box"",""20Rnd_762x51_Mag"",""1Rnd_HE_Grenade_shell"",""1Rnd_Smoke_Grenade_shell"",""1Rnd_SmokeGreen_Grenade_shell"",""Chemlight_blue"",""RPG32_F"",""RPG32_HE_F"",""HandGrenade"",""MiniGrenade"",""SmokeShell"",""SmokeShellGreen"",""UGL_FlareWhite_F"",""UGL_FlareGreen_F""],[24,6,12,6,2,2,6,3,1,6,6,2,2,2,2]],[[""Binocular"",""Rangefinder"",""FirstAidKit"",""acc_flashlight"",""bipod_03_F_oli"",""V_Chestrig_oli"",""V_TacVest_blk""],[1,1,10,2,2,4,4]],[[""B_TacticalPack_blk""],[2]]],false]";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item28
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1505.8157,5.8924227,563.55298};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""crate_med"",this,""ind_e_f""] call f_fnc_assignGear";
+				name="CrateLDF_C";
+			};
+			id=2373;
+			type="I_EAF_supplyCrate_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="ammoBox";
+					expression="[_this,_value] call bis_fnc_initAmmoBox;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[[[[""launch_RPG32_F"",""arifle_TRG20_F"",""arifle_TRG21_F"",""arifle_TRG21_GL_F"",""srifle_DMR_06_camo_F"",""srifle_DMR_06_olive_F"",""LMG_Mk200_F""],[1,1,4,1,1,1,2]],[[""30Rnd_556x45_Stanag"",""200Rnd_65x39_cased_Box"",""20Rnd_762x51_Mag"",""1Rnd_HE_Grenade_shell"",""1Rnd_Smoke_Grenade_shell"",""1Rnd_SmokeGreen_Grenade_shell"",""Chemlight_blue"",""RPG32_F"",""RPG32_HE_F"",""HandGrenade"",""MiniGrenade"",""SmokeShell"",""SmokeShellGreen"",""UGL_FlareWhite_F"",""UGL_FlareGreen_F""],[24,6,12,6,2,2,6,3,1,6,6,2,2,2,2]],[[""Binocular"",""Rangefinder"",""FirstAidKit"",""acc_flashlight"",""bipod_03_F_oli"",""V_Chestrig_oli"",""V_TacVest_blk""],[1,1,10,2,2,4,4]],[[""B_TacticalPack_blk""],[2]]],false]";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item29
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=4;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1372.5498,5.0014391,558.7395};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="COLONEL";
+						init="[""co"",this] call f_fnc_assignGear;";
+						name="UnitLDF_CO";
+						description="LDF Commander";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2090;
+					type="I_E_Officer_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1377.5498,5.0014391,557.08911};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""jtac"",this] call f_fnc_assignGear;";
+						name="UnitLDF_CO_JTAC";
+						description="LDF Forward Observer";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2091;
+					type="I_E_Officer_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1367.5498,5.0014391,557.08911};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""uav"",this] call f_fnc_assignGear;";
+						name="UnitLDF_CO_UAV";
+						description="LDF UAV Operator";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2092;
+					type="I_E_Soldier_UAV_F";
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1382.5498,5.0014391,554.34985};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""m"",this] call f_fnc_assignGear;";
+						name="UnitLDF_CO_M";
+						description="LDF Medic";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2093;
+					type="I_E_Medic_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_CO";
+			};
+			id=2089;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF CO -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item30
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=4;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1372.8486,5.0014391,529.15942};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="MAJOR";
+						init="[""dc"",this] call f_fnc_assignGear;";
+						name="UnitLDF_DC";
+						description="LDF Deputy Commander";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2095;
+					type="I_E_Officer_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male02POL";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1377.8486,5.0014391,527.50903};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""jtac"",this] call f_fnc_assignGear;";
+						name="UnitLDF_DC_JTAC";
+						description="LDF Forward Observer";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2096;
+					type="I_E_Officer_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male02POL";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1367.8486,5.0014391,527.50903};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""uav"",this] call f_fnc_assignGear;";
+						name="UnitLDF_DC_UAV";
+						description="LDF UAV Operator";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2097;
+					type="I_E_Soldier_UAV_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male02POL";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1382.8486,5.0014391,524.76978};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""m"",this] call f_fnc_assignGear;";
+						name="UnitLDF_DC_M";
+						description="LDF Medic";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2098;
+					type="I_E_Medic_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male02POL";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_DC";
+				init="DC";
+			};
+			id=2094;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF DC -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item31
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1371.785,7.6137953,468.95001};
+			};
+			side="Independent";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""v_ifv"",this] call f_fnc_assignGear;";
+				name="VehLDF_COV";
+			};
+			id=2028;
+			type="I_E_APC_tracked_03_cannon_F";
+			atlOffset=0.10300016;
+		};
+		class Item32
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=3;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1371.785,5.1044393,469};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""vc"",this] call f_fnc_assignGear;";
+						name="UnitLDF_COV_C";
+						description="LDF Command Vehicle Commander";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2025;
+					type="I_E_Crew_F";
+					atlOffset=0.10300016;
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1371.785,5.1044393,469};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""vg"",this] call f_fnc_assignGear;";
+						name="UnitLDF_COV_G";
+						description="LDF Command Vehicle Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2026;
+					type="I_E_Crew_F";
+					atlOffset=0.10300016;
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1371.785,5.1044393,469};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""vd"",this] call f_fnc_assignGear;";
+						name="UnitLDF_COV_D";
+						description="LDF Command Vehicle Driver (Repair)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2027;
+					type="I_E_Crew_F";
+					atlOffset=0.10300016;
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_COV";
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=3;
+				};
+				class Links
+				{
+					items=3;
+					class Item0
+					{
+						linkID=0;
+						item0=2025;
+						item1=2028;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0,0};
+						};
+					};
+					class Item1
+					{
+						linkID=1;
+						item0=2026;
+						item1=2028;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+					class Item2
+					{
+						linkID=2;
+						item0=2027;
+						item1=2028;
+						class CustomData
+						{
+							role=1;
+						};
+					};
+				};
+			};
+			id=2024;
+			atlOffset=0.10300016;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF COV -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item33
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1413.4414,5.0014391,557.36743};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CAPTAIN";
+						init="[""dc"",this] call f_fnc_assignGear;";
+						name="UnitLDF_ASL_SL";
+						description="LDF Alpha Squad Leader";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2100;
+					type="I_E_Soldier_SL_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male02POL";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1418.4414,5.0014391,555.71704};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""m"",this] call f_fnc_assignGear;";
+						name="UnitLDF_ASL_M";
+						description="LDF Alpha Medic";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2101;
+					type="I_E_Medic_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male02POL";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_ASL";
+			};
+			id=2099;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF ASL -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item34
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=6;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1414.377,5.0014391,530.0813};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="LIEUTENANT";
+						init="[""FTL"",this] call f_fnc_assignGear;";
+						name="UnitLDF_A1_FTL";
+						description="LDF Alpha 1 Fire Team Leader";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2103;
+					type="I_E_Soldier_TL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1419.377,5.0014391,528.43091};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""ar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_A1_AR1";
+						description="LDF Alpha 1 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2104;
+					type="I_E_Soldier_AR_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1409.377,5.0014391,528.43091};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""ar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_A1_AR2";
+						description="LDF Alpha 1 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2105;
+					type="I_E_Soldier_AR_F";
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1424.377,5.0014391,525.69263};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""rat"",this] call f_fnc_assignGear;";
+						name="UnitLDF_A1_AT";
+						description="LDF Alpha 1 Assaultman (AT)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2106;
+					type="I_E_Soldier_LAT_F";
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1404.377,5.0014391,525.69263};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""aar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_A1_R1";
+						description="LDF Alpha 1 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2107;
+					type="I_E_Soldier_F";
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1429.377,5.0014391,521.14478};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""aar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_A1_R2";
+						description="LDF Alpha 1 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2108;
+					type="I_E_Soldier_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_A1";
+			};
+			id=2102;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF A1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item35
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=6;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1414.1133,5.0014391,504.26099};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="LIEUTENANT";
+						init="[""FTL"",this] call f_fnc_assignGear;";
+						name="UnitLDF_A2_FTL";
+						description="LDF Alpha 2 Fire Team Leader";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2110;
+					type="I_E_Soldier_TL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1419.1133,5.0014391,502.6106};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""ar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_A2_AR1";
+						description="LDF Alpha 2 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2111;
+					type="I_E_Soldier_AR_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1409.1133,5.0014391,502.6106};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""ar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_A2_AR2";
+						description="LDF Alpha 2 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2112;
+					type="I_E_Soldier_AR_F";
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1424.1133,5.0014391,499.87134};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""rat"",this] call f_fnc_assignGear;";
+						name="UnitLDF_A2_AT";
+						description="LDF Alpha 2 Assaultman (AT)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2113;
+					type="I_E_Soldier_LAT_F";
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1404.1133,5.0014391,499.87134};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""aar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_A2_R1";
+						description="LDF Alpha 2 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2114;
+					type="I_E_Soldier_F";
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1429.1133,5.0014391,495.32544};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""aar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_A2_R2";
+						description="LDF Alpha 2 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2115;
+					type="I_E_Soldier_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_A2";
+			};
+			id=2109;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF A2 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item36
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1416.485,7.6137953,467.81};
+			};
+			side="Independent";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""v_ifv"",this] call f_fnc_assignGear;";
+				name="VehLDF_AV";
+			};
+			id=2033;
+			type="I_E_APC_tracked_03_cannon_F";
+			atlOffset=0.10300016;
+		};
+		class Item37
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=3;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1416.485,5.1044393,467.85999};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""vc"",this] call f_fnc_assignGear;";
+						name="UnitLDF_AV_C";
+						description="LDF Alpha Vehicle Commander";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2030;
+					type="I_E_Crew_F";
+					atlOffset=0.10300016;
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1416.485,5.1044393,467.85999};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""vg"",this] call f_fnc_assignGear;";
+						name="UnitLDF_AV_G";
+						description="LDF Alpha Vehicle Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2031;
+					type="I_E_Crew_F";
+					atlOffset=0.10300016;
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1416.485,5.1044393,467.85999};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""vd"",this] call f_fnc_assignGear;";
+						name="UnitLDF_AV_D";
+						description="LDF Alpha Vehicle Driver (Repair)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2032;
+					type="I_E_Crew_F";
+					atlOffset=0.10300016;
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_AV";
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=3;
+				};
+				class Links
+				{
+					items=3;
+					class Item0
+					{
+						linkID=0;
+						item0=2030;
+						item1=2033;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0,0};
+						};
+					};
+					class Item1
+					{
+						linkID=1;
+						item0=2031;
+						item1=2033;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+					class Item2
+					{
+						linkID=2;
+						item0=2032;
+						item1=2033;
+						class CustomData
+						{
+							role=1;
+						};
+					};
+				};
+			};
+			id=2029;
+			atlOffset=0.10300016;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF AV -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item38
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1456.542,5.0014391,557.46509};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CAPTAIN";
+						init="[""dc"",this] call f_fnc_assignGear;";
+						name="UnitLDF_BSL_SL";
+						description="LDF Bravo Squad Leader";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2117;
+					type="I_E_Soldier_SL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1461.542,5.0014391,555.8147};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""m"",this] call f_fnc_assignGear;";
+						name="UnitLDF_BSL_M";
+						description="LDF Bravo Medic";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2118;
+					type="I_E_Medic_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_BSL";
+			};
+			id=2116;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF BSL -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item39
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=6;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1456.7939,5.0014391,530.02954};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="LIEUTENANT";
+						init="[""FTL"",this] call f_fnc_assignGear;";
+						name="UnitLDF_B1_FTL";
+						description="LDF Bravo 1 Fire Team Leader";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2120;
+					type="I_E_Soldier_TL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1461.7939,5.0014391,528.37915};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""ar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_B1_AR1";
+						description="LDF Bravo 1 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2121;
+					type="I_E_Soldier_AR_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1451.7939,5.0014391,528.37915};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""ar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_B1_AR2";
+						description="LDF Bravo 1 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2122;
+					type="I_E_Soldier_AR_F";
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1466.7939,5.0014391,525.63989};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""rat"",this] call f_fnc_assignGear;";
+						name="UnitLDF_B1_AT";
+						description="LDF Bravo 1 Assaultman (AT)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2123;
+					type="I_E_Soldier_LAT_F";
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1446.7939,5.0014391,525.63989};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""aar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_B1_R1";
+						description="LDF Bravo 1 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2124;
+					type="I_E_Soldier_F";
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1471.7939,5.0014391,521.09302};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""aar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_B1_R2";
+						description="LDF Bravo 1 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2125;
+					type="I_E_Soldier_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_B1";
+			};
+			id=2119;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF B1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item40
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=6;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1456.4775,5.0014391,503.73657};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="LIEUTENANT";
+						init="[""FTL"",this] call f_fnc_assignGear;";
+						name="UnitLDF_B2_FTL";
+						description="LDF Bravo 2 Fire Team Leader";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2127;
+					type="I_E_Soldier_TL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1461.4775,5.0014391,502.08716};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""ar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_B2_AR1";
+						description="LDF Bravo 2 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2128;
+					type="I_E_Soldier_AR_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1451.4775,5.0014391,502.08716};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""ar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_B2_AR2";
+						description="LDF Bravo 2 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2129;
+					type="I_E_Soldier_AR_F";
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1466.4775,5.0014391,499.34692};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""rat"",this] call f_fnc_assignGear;";
+						name="UnitLDF_B2_AT";
+						description="LDF Bravo 2 Assaultman (AT)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2130;
+					type="I_E_Soldier_LAT_F";
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1446.4775,5.0014391,499.34692};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""aar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_B2_R1";
+						description="LDF Bravo 2 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2131;
+					type="I_E_Soldier_F";
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1471.4775,5.0014391,494.80005};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""aar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_B2_R2";
+						description="LDF Bravo 2 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2132;
+					type="I_E_Soldier_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_B2";
+			};
+			id=2126;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF B2 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item41
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1457.302,7.6137953,467.875};
+			};
+			side="Independent";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""v_ifv"",this] call f_fnc_assignGear;";
+				name="VehLDF_BV";
+			};
+			id=2038;
+			type="I_E_APC_tracked_03_cannon_F";
+			atlOffset=0.10300016;
+		};
+		class Item42
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=3;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1457.302,5.1044393,467.92499};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""vc"",this] call f_fnc_assignGear;";
+						name="UnitLDF_BV_C";
+						description="LDF Bravo Vehicle Commander";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2035;
+					type="I_E_Crew_F";
+					atlOffset=0.10300016;
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1457.302,5.1044393,467.92499};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""vg"",this] call f_fnc_assignGear;";
+						name="UnitLDF_BV_G";
+						description="LDF Bravo Vehicle Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2036;
+					type="I_E_Crew_F";
+					atlOffset=0.10300016;
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1457.302,5.1044393,467.92499};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""vd"",this] call f_fnc_assignGear;";
+						name="UnitLDF_BV_D";
+						description="LDF Bravo Vehicle Driver (Repair)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2037;
+					type="I_E_Crew_F";
+					atlOffset=0.10300016;
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_BV";
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=3;
+				};
+				class Links
+				{
+					items=3;
+					class Item0
+					{
+						linkID=0;
+						item0=2035;
+						item1=2038;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0,0};
+						};
+					};
+					class Item1
+					{
+						linkID=1;
+						item0=2036;
+						item1=2038;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+					class Item2
+					{
+						linkID=2;
+						item0=2037;
+						item1=2038;
+						class CustomData
+						{
+							role=1;
+						};
+					};
+				};
+			};
+			id=2034;
+			atlOffset=0.10300016;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF BV -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item43
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1499.3818,5.0014391,556.94556};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CAPTAIN";
+						init="[""dc"",this] call f_fnc_assignGear;";
+						name="UnitLDF_CSL_SL";
+						description="LDF Charlie Squad Leader";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2134;
+					type="I_E_Soldier_SL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1504.3818,5.0014391,555.29517};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""m"",this] call f_fnc_assignGear;";
+						name="UnitLDF_CSL_M";
+						description="LDF Charlie Medic";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2135;
+					type="I_E_Medic_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_CSL";
+			};
+			id=2133;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF CSL -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item44
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=6;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1500.0381,5.0014391,528.6272};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="LIEUTENANT";
+						init="[""FTL"",this] call f_fnc_assignGear;";
+						name="UnitLDF_C1_FTL";
+						description="LDF Charlie 1 Fire Team Leader";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2137;
+					type="I_E_Soldier_TL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1505.0381,5.0014391,526.97681};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""ar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_C1_AR1";
+						description="LDF Charlie 1 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2138;
+					type="I_E_Soldier_AR_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1495.0381,5.0014391,526.97681};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""ar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_C1_AR2";
+						description="LDF Charlie 1 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2139;
+					type="I_E_Soldier_AR_F";
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1510.0381,5.0014391,524.23755};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""rat"",this] call f_fnc_assignGear;";
+						name="UnitLDF_C1_AT";
+						description="LDF Charlie 1 Assaultman (AT)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2140;
+					type="I_E_Soldier_LAT_F";
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1490.0381,5.0014391,524.23755};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""aar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_C1_R1";
+						description="LDF Charlie 1 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2141;
+					type="I_E_Soldier_F";
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1515.0381,5.0014391,519.69067};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""aar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_C1_R2";
+						description="LDF Charlie 1 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2142;
+					type="I_E_Soldier_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_C1";
+			};
+			id=2136;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF C1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item45
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=6;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1499.7188,5.0014391,503.6897};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="LIEUTENANT";
+						init="[""FTL"",this] call f_fnc_assignGear;";
+						name="UnitLDF_C2_FTL";
+						description="LDF Charlie 2 Fire Team Leader";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2144;
+					type="I_E_Soldier_TL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1504.7188,5.0014391,502.03833};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""ar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_C2_AR1";
+						description="LDF Charlie 2 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2145;
+					type="I_E_Soldier_AR_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1494.7188,5.0014391,502.03833};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""ar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_C2_AR2";
+						description="LDF Charlie 2 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2146;
+					type="I_E_Soldier_AR_F";
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1509.7188,5.0014391,499.30005};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""rat"",this] call f_fnc_assignGear;";
+						name="UnitLDF_C2_AT";
+						description="LDF Charlie 2 Assaultman (AT)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2147;
+					type="I_E_Soldier_LAT_F";
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1489.7188,5.0014391,499.30005};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""aar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_C2_R1";
+						description="LDF Charlie 2 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2148;
+					type="I_E_Soldier_F";
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1514.7188,5.0014391,494.75317};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""aar"",this] call f_fnc_assignGear;";
+						name="UnitLDF_C2_R2";
+						description="LDF Charlie 2 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2149;
+					type="I_E_Soldier_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_C2";
+			};
+			id=2143;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF C2 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item46
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1498.854,7.6137953,468.159};
+			};
+			side="Independent";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""v_ifv"",this] call f_fnc_assignGear;";
+				name="VehLDF_CV";
+			};
+			id=2043;
+			type="I_E_APC_tracked_03_cannon_F";
+			atlOffset=0.10300016;
+		};
+		class Item47
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=3;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1498.854,5.1044393,468.20898};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""vc"",this] call f_fnc_assignGear;";
+						name="UnitLDF_CV_C";
+						description="LDF Charlie Vehicle Commander";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2040;
+					type="I_E_Crew_F";
+					atlOffset=0.10300016;
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1498.854,5.1044393,468.20898};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""vg"",this] call f_fnc_assignGear;";
+						name="UnitLDF_CV_G";
+						description="LDF Charlie Vehicle Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2041;
+					type="I_E_Crew_F";
+					atlOffset=0.10300016;
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1498.854,5.1044393,468.20898};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""vd"",this] call f_fnc_assignGear;";
+						name="UnitLDF_CV_D";
+						description="LDF Charlie Vehicle Driver (Repair)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2042;
+					type="I_E_Crew_F";
+					atlOffset=0.10300016;
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_CV";
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=3;
+				};
+				class Links
+				{
+					items=3;
+					class Item0
+					{
+						linkID=0;
+						item0=2040;
+						item1=2043;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0,0};
+						};
+					};
+					class Item1
+					{
+						linkID=1;
+						item0=2041;
+						item1=2043;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+					class Item2
+					{
+						linkID=2;
+						item0=2042;
+						item1=2043;
+						class CustomData
+						{
+							role=1;
+						};
+					};
+				};
+			};
+			id=2039;
+			atlOffset=0.10300016;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF CV -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item48
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=3;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1557.7844,5.0014391,555.58716};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""mmgl"",this] call f_fnc_assignGear;";
+						name="UnitLDF_MMG1_TL";
+						description="LDF Medium MG Team 1 Spotter (Leader)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2151;
+					type="I_E_Soldier_TL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1562.7842,5.0014391,553.93677};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""mmgg"",this] call f_fnc_assignGear;";
+						name="UnitLDF_MMG1_G";
+						description="LDF Medium MG Team 1 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2152;
+					type="I_E_Soldier_AR_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1553.6216,5.0014391,553.96533};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""mmgag"",this] call f_fnc_assignGear;";
+						name="UnitLDF_MMG1_AG";
+						description="LDF Medium MG Team 1 Assistant";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2153;
+					type="I_E_Soldier_AAR_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_MMG1";
+			};
+			id=2150;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF MMG1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item49
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=3;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1557.8096,5.0014391,540.84521};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""mmgl"",this] call f_fnc_assignGear;";
+						name="UnitLDF_MMG2_TL";
+						description="LDF Medium MG Team 2 Spotter (Leader)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2155;
+					type="I_E_Soldier_TL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1562.8096,5.0014391,539.19458};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""mmgg"",this] call f_fnc_assignGear;";
+						name="UnitLDF_MMG2_G";
+						description="LDF Medium MG Team 2 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2156;
+					type="I_E_Soldier_AR_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1553.6475,5.0014391,539.22339};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""mmgag"",this] call f_fnc_assignGear;";
+						name="UnitLDF_MMG2_AG";
+						description="LDF Medium MG Team 2 Assistant";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2157;
+					type="I_E_Soldier_AAR_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_MMG2";
+			};
+			id=2154;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF MMG2 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item50
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=3;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1557.9155,5.0014391,527.56909};
+						angles[]={0,0.030927233,0};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""matl"",this] call f_fnc_assignGear;  ";
+						name="UnitLDF_MAT1_TL";
+						description="LDF Medium AT Team 1 Spotter (Leader)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2159;
+					type="I_E_Soldier_TL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1562.915,5.0014391,525.91919};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""matg"",this] call f_fnc_assignGear;  ";
+						name="UnitLDF_MAT1_G";
+						description="LDF Medium AT Team 1 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2160;
+					type="I_E_Soldier_AT_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1553.7524,5.0014391,525.94824};
+						angles[]={0,0.030927233,0};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""matag"",this] call f_fnc_assignGear;  ";
+						name="UnitLDF_MAT1_AG";
+						description="LDF Medium AT Team 1 Assistant";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2161;
+					type="I_E_Soldier_AAT_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_MAT1";
+			};
+			id=2158;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF MAT1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item51
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=3;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1558.3345,5.0014391,516.03418};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""matl"",this] call f_fnc_assignGear; ";
+						name="UnitLDF_MAT2_TL";
+						description="LDF Medium AT Team 2 Spotter (Leader)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2163;
+					type="I_E_Soldier_TL_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male02POL";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1563.334,5.0014391,514.38403};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""matg"",this] call f_fnc_assignGear; ";
+						name="UnitLDF_MAT2_G";
+						description="LDF Medium AT Team 2 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2164;
+					type="I_E_Soldier_AT_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male02POL";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1554.1714,5.0014391,514.41333};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""matag"",this] call f_fnc_assignGear; ";
+						name="UnitLDF_MAT2_AG";
+						description="LDF Medium AT Team 2 Assistant";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2165;
+					type="I_E_Soldier_AAT_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male02POL";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_MAT2";
+			};
+			id=2162;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF MAT2 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item52
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1558.2803,5.0014391,502.91431};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""hmgag"",this] call f_fnc_assignGear;  ";
+						name="UnitLDF_HMG1_TL";
+						description="LDF Heavy MG Team 1 Spotter (Leader)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2167;
+					type="I_E_Soldier_TL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1563.2803,5.0014391,501.26392};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""hmgg"",this] call f_fnc_assignGear;  ";
+						name="UnitLDF_HMG1_G";
+						description="LDF Heavy MG Team 1 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2168;
+					type="I_E_Support_MG_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_HMG1";
+			};
+			id=2166;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF HMG1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item53
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=3;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1558.2666,5.0014391,491.53516};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""hatl"",this] call f_fnc_assignGear; ";
+						name="UnitLDF_HAT1_TL";
+						description="LDF Heavy AT Team 1 Spotter (Leader)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2170;
+					type="I_E_Soldier_TL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1563.2666,5.0014391,489.88501};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""hatg"",this] call f_fnc_assignGear; ";
+						name="UnitLDF_HAT1_G";
+						description="LDF Heavy AT Team 1 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2171;
+					type="I_E_Soldier_AT_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1554.1045,5.0014391,489.91431};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""hatag"",this] call f_fnc_assignGear; ";
+						name="UnitLDF_HAT1_AG";
+						description="LDF Heavy AT Team 1 Assistant";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2172;
+					type="I_E_Soldier_AAT_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_HAT1";
+			};
+			id=2169;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF HAT1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item54
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1558.2676,5.0014391,479.41626};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""mtrag"",this] call f_fnc_assignGear; ";
+						name="UnitLDF_MTR1_TL";
+						description="LDF Mortar Team 1 Spotter (Leader)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2174;
+					type="I_E_Support_AMort_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1563.2676,5.0014391,477.76587};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""mtrg"",this] call f_fnc_assignGear; ";
+						name="UnitLDF_MTR1_G";
+						description="LDF Mortar Team 1 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2175;
+					type="I_E_Support_Mort_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_MTR1";
+			};
+			id=2173;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF MTR1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item55
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=3;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1558.0566,5.0014391,467.41821};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""msaml"",this] call f_fnc_assignGear; ";
+						name="UnitLDF_MSAM1_TL";
+						description="LDF Medium SAM Team 1 Spotter (Leader)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2177;
+					type="I_E_Soldier_AAA_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1563.0566,5.0014391,465.76782};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""msamg"",this] call f_fnc_assignGear; ";
+						name="UnitLDF_MSAM1_G";
+						description="LDF Medium SAM Team 1 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2178;
+					type="I_E_Soldier_AA_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1553.8945,5.0014391,465.79614};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""msamag"",this] call f_fnc_assignGear; ";
+						name="UnitLDF_MSAM1_AG";
+						description="LDF Medium SAM Team 1 Assistant";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2179;
+					type="I_E_Soldier_AAA_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_MSAM1";
+			};
+			id=2176;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF MSAM1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item56
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1558.2324,5.0014391,454.23657};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""hsamag"",this] call f_fnc_assignGear; ";
+						name="UnitLDF_HSAM1_TL";
+						description="LDF Heavy SAM Team 1 Spotter (Leader)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2181;
+					type="I_E_Soldier_AAA_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1563.2324,5.0014391,452.58618};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""hsamg"",this] call f_fnc_assignGear; ";
+						name="UnitLDF_HSAM1_G";
+						description="LDF Heavy SAM Team 1 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2182;
+					type="I_E_Soldier_AA_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_HSAM1";
+			};
+			id=2180;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF HSAM1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item57
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1557.9316,5.0014391,443.3999};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""sp"",this] call f_fnc_assignGear; ";
+						name="UnitLDF_ST1_SP";
+						description="LDF Sniper Team 1 Spotter (Leader)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2383;
+					type="I_E_Soldier_Pathfinder_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male03POL";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=0.95999998;
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1562.9316,5.0014391,441.75};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""sn"",this] call f_fnc_assignGear; ";
+						name="UnitLDF_ST1_G";
+						description="LDF Sniper Team 1 Sniper";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2384;
+					type="I_E_soldier_M_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male02POL";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=0.97000003;
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_ST1";
+			};
+			id=2380;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF ST1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item58
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=4;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1559,5.0014391,430.05005};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""eng"",this] call f_fnc_assignGear; ";
+						name="UnitLDF_ENG1_FTL";
+						description="LDF Engineer Team 1 Leader (Demo)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2187;
+					type="I_E_Engineer_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1564,5.0014391,428.40063};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""eng"",this] call f_fnc_assignGear; ";
+						name="UnitLDF_ENG1_A1";
+						description="LDF Engineer Team 1 Assistant (Demo)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2188;
+					type="I_E_Engineer_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1554,5.0014391,428.40063};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""engm"",this] call f_fnc_assignGear; ";
+						name="UnitLDF_ENG1_A2";
+						description="LDF Engineer Team 1 Assistant (Mines)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2189;
+					type="I_E_Engineer_F";
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1569,5.0014391,425.6604};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""engm"",this] call f_fnc_assignGear; ";
+						name="UnitLDF_ENG1_A3";
+						description="LDF Engineer Team 1 Assistant (Mines)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2190;
+					type="I_E_Engineer_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_ENG1";
+			};
+			id=2186;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF ENG1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item59
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1372.501,7.6857953,445.76001};
+			};
+			side="Independent";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""v_ifv"",this] call f_fnc_assignGear;";
+				name="VehLDF_IFV1";
+				textures="EAF_01";
+			};
+			id=2065;
+			type="I_E_APC_tracked_03_cannon_F";
+			atlOffset=0.17500019;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="VehicleCustomization";
+					expression="if (local _this) then {if (isSimpleObject _this) then {_this setVariable ['bis_fnc_initVehicle_customization',_value]} else {([_this] + _value + [true]) call (uinamespace getvariable 'bis_fnc_initVehicle');};};";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"ARRAY"
+								};
+							};
+							class value
+							{
+								items=2;
+								class Item0
+								{
+									class data
+									{
+										class type
+										{
+											type[]=
+											{
+												"ARRAY"
+											};
+										};
+									};
+								};
+								class Item1
+								{
+									class data
+									{
+										class type
+										{
+											type[]=
+											{
+												"ARRAY"
+											};
+										};
+										class value
+										{
+											items=14;
+											class Item0
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="showBags";
+												};
+											};
+											class Item1
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"SCALAR"
+														};
+													};
+													value=0;
+												};
+											};
+											class Item2
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="showBags2";
+												};
+											};
+											class Item3
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"SCALAR"
+														};
+													};
+													value=0;
+												};
+											};
+											class Item4
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="showCamonetHull";
+												};
+											};
+											class Item5
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"SCALAR"
+														};
+													};
+													value=0;
+												};
+											};
+											class Item6
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="showCamonetTurret";
+												};
+											};
+											class Item7
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"SCALAR"
+														};
+													};
+													value=0;
+												};
+											};
+											class Item8
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="showTools";
+												};
+											};
+											class Item9
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"SCALAR"
+														};
+													};
+													value=0;
+												};
+											};
+											class Item10
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="showSLATHull";
+												};
+											};
+											class Item11
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"SCALAR"
+														};
+													};
+													value=1;
+												};
+											};
+											class Item12
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="showSLATTurret";
+												};
+											};
+											class Item13
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"SCALAR"
+														};
+													};
+													value=1;
+												};
+											};
+										};
+									};
+								};
+							};
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item60
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=3;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1372.501,5.1764393,445.81};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""vc"",this] call f_fnc_assignGear;";
+						name="UnitLDF_IFV1_C";
+						description="LDF IFV 1 Commander";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2062;
+					type="I_E_Crew_F";
+					atlOffset=0.17500019;
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1372.501,5.1764393,445.81};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""vg"",this] call f_fnc_assignGear;";
+						name="UnitLDF_IFV1_G";
+						description="LDF IFV 1 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2063;
+					type="I_E_Crew_F";
+					atlOffset=0.17500019;
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1372.501,5.1764393,445.81};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""vd"",this] call f_fnc_assignGear;";
+						name="UnitLDF_IFV1_D";
+						description="LDF IFV 1 Driver (Repair)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2064;
+					type="I_E_Crew_F";
+					atlOffset=0.17500019;
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_IFV1";
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=3;
+				};
+				class Links
+				{
+					items=3;
+					class Item0
+					{
+						linkID=0;
+						item0=2062;
+						item1=2065;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0,0};
+						};
+					};
+					class Item1
+					{
+						linkID=1;
+						item0=2063;
+						item1=2065;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+					class Item2
+					{
+						linkID=2;
+						item0=2064;
+						item1=2065;
+						class CustomData
+						{
+							role=1;
+						};
+					};
+				};
+			};
+			id=2061;
+			atlOffset=0.17500019;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF IFV1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item61
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1415.702,7.5107951,443.41299};
+			};
+			side="Independent";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""v_ifv"",this] call f_fnc_assignGear;";
+				name="VehLDF_IFV2";
+				textures="EAF_01";
+			};
+			id=2070;
+			type="I_E_APC_tracked_03_cannon_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="VehicleCustomization";
+					expression="if (local _this) then {if (isSimpleObject _this) then {_this setVariable ['bis_fnc_initVehicle_customization',_value]} else {([_this] + _value + [true]) call (uinamespace getvariable 'bis_fnc_initVehicle');};};";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"ARRAY"
+								};
+							};
+							class value
+							{
+								items=2;
+								class Item0
+								{
+									class data
+									{
+										class type
+										{
+											type[]=
+											{
+												"ARRAY"
+											};
+										};
+									};
+								};
+								class Item1
+								{
+									class data
+									{
+										class type
+										{
+											type[]=
+											{
+												"ARRAY"
+											};
+										};
+										class value
+										{
+											items=14;
+											class Item0
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="showBags";
+												};
+											};
+											class Item1
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"SCALAR"
+														};
+													};
+													value=0;
+												};
+											};
+											class Item2
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="showBags2";
+												};
+											};
+											class Item3
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"SCALAR"
+														};
+													};
+													value=0;
+												};
+											};
+											class Item4
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="showCamonetHull";
+												};
+											};
+											class Item5
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"SCALAR"
+														};
+													};
+													value=0;
+												};
+											};
+											class Item6
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="showCamonetTurret";
+												};
+											};
+											class Item7
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"SCALAR"
+														};
+													};
+													value=0;
+												};
+											};
+											class Item8
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="showTools";
+												};
+											};
+											class Item9
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"SCALAR"
+														};
+													};
+													value=0;
+												};
+											};
+											class Item10
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="showSLATHull";
+												};
+											};
+											class Item11
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"SCALAR"
+														};
+													};
+													value=1;
+												};
+											};
+											class Item12
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="showSLATTurret";
+												};
+											};
+											class Item13
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"SCALAR"
+														};
+													};
+													value=1;
+												};
+											};
+										};
+									};
+								};
+							};
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item62
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=3;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1415.702,5.0014391,443.46298};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""vc"",this] call f_fnc_assignGear;";
+						name="UnitLDF_IFV2_C";
+						description="LDF IFV 2 Commander";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2067;
+					type="I_E_Crew_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1415.702,5.0014391,443.46298};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[""vg"",this] call f_fnc_assignGear;";
+						name="UnitLDF_IFV2_G";
+						description="LDF IFV 2 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2068;
+					type="I_E_Crew_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1415.702,5.0014391,443.46298};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[""vd"",this] call f_fnc_assignGear;";
+						name="UnitLDF_IFV2_D";
+						description="LDF IFV 2 Driver (Repair)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2069;
+					type="I_E_Crew_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_IFV2";
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=3;
+				};
+				class Links
+				{
+					items=3;
+					class Item0
+					{
+						linkID=0;
+						item0=2067;
+						item1=2070;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0,0};
+						};
+					};
+					class Item1
+					{
+						linkID=1;
+						item0=2068;
+						item1=2070;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+					class Item2
+					{
+						linkID=2;
+						item0=2069;
+						item1=2070;
+						class CustomData
+						{
+							role=1;
+						};
+					};
+				};
+			};
+			id=2066;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF IFV2 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item63
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1372.386,6.8630314,411.42014};
+			};
+			side="Independent";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""v_helo_h"",this] call f_fnc_assignGear";
+				name="VehLDF_TH1";
+			};
+			id=2011;
+			type="I_E_Heli_light_03_unarmed_F";
+		};
+		class Item64
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1372.386,5.0014391,411.46899};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="LIEUTENANT";
+						init="[""pc"",this] call f_fnc_assignGear;";
+						name="UnitLDF_TH1_P";
+						description="LDF Transport Helo 1 Pilot";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2009;
+					type="I_E_Helipilot_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1372.386,5.0014391,411.46899};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""pc"",this] call f_fnc_assignGear;";
+						name="UnitLDF_TH1_CP";
+						description="LDF Transport Helo 1 Co-Pilot";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2010;
+					type="I_E_Helipilot_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_TH1";
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=2;
+				};
+				class Links
+				{
+					items=2;
+					class Item0
+					{
+						linkID=0;
+						item0=2009;
+						item1=2011;
+						class CustomData
+						{
+							role=1;
+						};
+					};
+					class Item1
+					{
+						linkID=1;
+						item0=2010;
+						item1=2011;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+				};
+			};
+			id=2008;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF TH1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item65
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1415.469,6.8630314,412.25912};
+			};
+			side="Independent";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""v_helo_h"",this] call f_fnc_assignGear";
+				name="VehLDF_TH2";
+			};
+			id=2015;
+			type="I_E_Heli_light_03_unarmed_F";
+		};
+		class Item66
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1415.469,5.0014391,412.30798};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="LIEUTENANT";
+						init="[""pc"",this] call f_fnc_assignGear;";
+						name="UnitLDF_TH2_P";
+						description="LDF Transport Helo 2 Pilot";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2013;
+					type="I_E_Helipilot_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1415.469,5.0014391,412.30798};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""pc"",this] call f_fnc_assignGear;";
+						name="UnitLDF_TH2_CP";
+						description="LDF Transport Helo 2 Co-Pilot";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2014;
+					type="I_E_Helipilot_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_TH2";
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=2;
+				};
+				class Links
+				{
+					items=2;
+					class Item0
+					{
+						linkID=0;
+						item0=2013;
+						item1=2015;
+						class CustomData
+						{
+							role=1;
+						};
+					};
+					class Item1
+					{
+						linkID=1;
+						item0=2014;
+						item1=2015;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+				};
+			};
+			id=2012;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF TH2 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item67
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1457.7159,6.8630314,413.10013};
+			};
+			side="Independent";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""v_helo_h"",this] call f_fnc_assignGear";
+				name="VehLDF_TH3";
+			};
+			id=2019;
+			type="I_E_Heli_light_03_unarmed_F";
+		};
+		class Item68
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1457.7159,5.0014391,413.14899};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="LIEUTENANT";
+						init="[""pc"",this] call f_fnc_assignGear;";
+						name="UnitLDF_TH3_P";
+						description="LDF Transport Helo 3 Pilot";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2017;
+					type="I_E_Helipilot_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1457.7159,5.0014391,413.14899};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""pc"",this] call f_fnc_assignGear;";
+						name="UnitLDF_TH3_CP";
+						description="LDF Transport Helo 3 Co-Pilot";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2018;
+					type="I_E_Helipilot_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_TH3";
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=2;
+				};
+				class Links
+				{
+					items=2;
+					class Item0
+					{
+						linkID=0;
+						item0=2017;
+						item1=2019;
+						class CustomData
+						{
+							role=1;
+						};
+					};
+					class Item1
+					{
+						linkID=1;
+						item0=2018;
+						item1=2019;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+				};
+			};
+			id=2016;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF TH3 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item69
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1499.0341,6.8630314,413.75613};
+			};
+			side="Independent";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+				fuel=0.29590145;
+				init="[""v_helo_h"",this] call f_fnc_assignGear";
+				name="VehLDF_TH4";
+			};
+			id=2023;
+			type="I_E_Heli_light_03_unarmed_F";
+		};
+		class Item70
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1499.0341,5.0014391,413.80499};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="LIEUTENANT";
+						init="[""pc"",this] call f_fnc_assignGear;";
+						name="UnitLDF_TH4_P";
+						description="LDF Transport Helo 4 Pilot";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2021;
+					type="I_E_Helipilot_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1499.0341,5.0014391,413.80499};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""pc"",this] call f_fnc_assignGear;";
+						name="UnitLDF_TH4_CP";
+						description="LDF Transport Helo 4 Co-Pilot";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2022;
+					type="I_E_Helipilot_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_TH4";
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=2;
+				};
+				class Links
+				{
+					items=2;
+					class Item0
+					{
+						linkID=0;
+						item0=2021;
+						item1=2023;
+						class CustomData
+						{
+							role=1;
+						};
+					};
+					class Item1
+					{
+						linkID=1;
+						item0=2022;
+						item1=2023;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+				};
+			};
+			id=2020;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF TH4 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item71
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1372.203,6.5310755,380.211};
+			};
+			side="Independent";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""v_helo_a"",this] call f_fnc_assignGear";
+				name="VehLDF_AH1";
+				receiveRemoteTargets=1;
+			};
+			id=2052;
+			type="I_E_Heli_light_03_dynamicLoadout_F";
+		};
+		class Item72
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1372.203,5.0014391,380.26099};
+					};
+					side="Independent";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="LIEUTENANT";
+						init="[""pc"",this] call f_fnc_assignGear;";
+						name="UnitLDF_AH1_P";
+						description="LDF Attack Helo 1 Pilot";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2050;
+					type="I_E_Helipilot_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1372.203,5.0014391,380.26099};
+					};
+					side="Independent";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[""pc"",this] call f_fnc_assignGear;";
+						name="UnitLDF_AH1_CP";
+						description="LDF Attack Helo 1 Co-Pilot";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2051;
+					type="I_E_Helipilot_F";
+				};
+			};
+			class Attributes
+			{
+				name="GrpLDF_AH1";
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=2;
+				};
+				class Links
+				{
+					items=2;
+					class Item0
+					{
+						linkID=0;
+						item0=2050;
+						item1=2052;
+						class CustomData
+						{
+							role=1;
+						};
+					};
+					class Item1
+					{
+						linkID=1;
+						item0=2051;
+						item1=2052;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+				};
+			};
+			id=2049;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="LDF AH1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item73
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2472.3262,5.8924227,969.11792};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[this,""npr""] call f_fnc_setVirtualFaction; [""crate_med"",this] call f_fnc_assignGear";
+				name="CrateNPR_A";
+			};
+			id=2385;
+			type="IG_supplyCrate_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="ammoBox";
+					expression="[_this,_value] call bis_fnc_initAmmoBox;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[[[[""launch_RPG32_F"",""arifle_TRG20_F"",""arifle_TRG21_F"",""arifle_TRG21_GL_F"",""srifle_DMR_06_camo_F"",""srifle_DMR_06_olive_F"",""LMG_Mk200_F""],[1,1,4,1,1,1,2]],[[""30Rnd_556x45_Stanag"",""200Rnd_65x39_cased_Box"",""20Rnd_762x51_Mag"",""1Rnd_HE_Grenade_shell"",""1Rnd_Smoke_Grenade_shell"",""1Rnd_SmokeGreen_Grenade_shell"",""Chemlight_blue"",""RPG32_F"",""RPG32_HE_F"",""HandGrenade"",""MiniGrenade"",""SmokeShell"",""SmokeShellGreen"",""UGL_FlareWhite_F"",""UGL_FlareGreen_F""],[24,6,12,6,2,2,6,3,1,6,6,2,2,2,2]],[[""Binocular"",""Rangefinder"",""FirstAidKit"",""acc_flashlight"",""bipod_03_F_oli"",""V_Chestrig_oli"",""V_TacVest_blk""],[1,1,10,2,2,4,4]],[[""B_TacticalPack_blk""],[2]]],false]";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item74
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2514.335,5.8924227,970.24878};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[this,""npr""] call f_fnc_setVirtualFaction; [""crate_med"",this] call f_fnc_assignGear";
+				name="CrateNPR_B";
+			};
+			id=2386;
+			type="IG_supplyCrate_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="ammoBox";
+					expression="[_this,_value] call bis_fnc_initAmmoBox;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[[[[""launch_RPG32_F"",""arifle_TRG20_F"",""arifle_TRG21_F"",""arifle_TRG21_GL_F"",""srifle_DMR_06_camo_F"",""srifle_DMR_06_olive_F"",""LMG_Mk200_F""],[1,1,4,1,1,1,2]],[[""30Rnd_556x45_Stanag"",""200Rnd_65x39_cased_Box"",""20Rnd_762x51_Mag"",""1Rnd_HE_Grenade_shell"",""1Rnd_Smoke_Grenade_shell"",""1Rnd_SmokeGreen_Grenade_shell"",""Chemlight_blue"",""RPG32_F"",""RPG32_HE_F"",""HandGrenade"",""MiniGrenade"",""SmokeShell"",""SmokeShellGreen"",""UGL_FlareWhite_F"",""UGL_FlareGreen_F""],[24,6,12,6,2,2,6,3,1,6,6,2,2,2,2]],[[""Binocular"",""Rangefinder"",""FirstAidKit"",""acc_flashlight"",""bipod_03_F_oli"",""V_Chestrig_oli"",""V_TacVest_blk""],[1,1,10,2,2,4,4]],[[""B_TacticalPack_blk""],[2]]],false]";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item75
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2554.291,5.8924227,969.04077};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[this,""npr""] call f_fnc_setVirtualFaction; [""crate_med"",this] call f_fnc_assignGear";
+				name="CrateNPR_C";
+			};
+			id=2387;
+			type="IG_supplyCrate_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="ammoBox";
+					expression="[_this,_value] call bis_fnc_initAmmoBox;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[[[[""launch_RPG32_F"",""arifle_TRG20_F"",""arifle_TRG21_F"",""arifle_TRG21_GL_F"",""srifle_DMR_06_camo_F"",""srifle_DMR_06_olive_F"",""LMG_Mk200_F""],[1,1,4,1,1,1,2]],[[""30Rnd_556x45_Stanag"",""200Rnd_65x39_cased_Box"",""20Rnd_762x51_Mag"",""1Rnd_HE_Grenade_shell"",""1Rnd_Smoke_Grenade_shell"",""1Rnd_SmokeGreen_Grenade_shell"",""Chemlight_blue"",""RPG32_F"",""RPG32_HE_F"",""HandGrenade"",""MiniGrenade"",""SmokeShell"",""SmokeShellGreen"",""UGL_FlareWhite_F"",""UGL_FlareGreen_F""],[24,6,12,6,2,2,6,3,1,6,6,2,2,2,2]],[[""Binocular"",""Rangefinder"",""FirstAidKit"",""acc_flashlight"",""bipod_03_F_oli"",""V_Chestrig_oli"",""V_TacVest_blk""],[1,1,10,2,2,4,4]],[[""B_TacticalPack_blk""],[2]]],false]";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item76
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={2416.0752,5,956.7937};
+			};
+			id=2388;
+			type="SupportProvider_Artillery";
+		};
+		class Item77
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={2418.1699,5.4784107,959.11792};
+			};
+			id=2393;
+			type="SupportRequester";
+			atlOffset=0.47841072;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="SupportRequester_BIS_SUPP_limit_UAV";
+					expression="_this setVariable ['BIS_SUPP_limit_UAV',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="SupportRequester_BIS_SUPP_custom_HQ";
+					expression="_this setVariable ['BIS_SUPP_custom_HQ',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="SupportRequester_BIS_SUPP_limit_Transport";
+					expression="_this setVariable ['BIS_SUPP_limit_Transport',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				class Attribute3
+				{
+					property="SupportRequester_BIS_SUPP_limit_Drop";
+					expression="_this setVariable ['BIS_SUPP_limit_Drop',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				class Attribute4
+				{
+					property="SupportRequester_BIS_SUPP_limit_CAS_Heli";
+					expression="_this setVariable ['BIS_SUPP_limit_CAS_Heli',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				class Attribute5
+				{
+					property="SupportRequester_BIS_SUPP_limit_Artillery";
+					expression="_this setVariable ['BIS_SUPP_limit_Artillery',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				class Attribute6
+				{
+					property="SupportRequester_BIS_SUPP_limit_CAS_Bombing";
+					expression="_this setVariable ['BIS_SUPP_limit_CAS_Bombing',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				nAttributes=7;
+			};
+		};
+		class Item78
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=1;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2416.0908,5.3587284,953.92017};
+					};
+					side="East";
+					flags=2;
+					class Attributes
+					{
+					};
+					id=2546;
+					type="O_G_Soldier_F";
+					atlOffset=0.35728931;
+				};
+			};
+			class Attributes
+			{
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=1;
+				};
+				class Links
+				{
+					items=1;
+					class Item0
+					{
+						linkID=0;
+						item0=2546;
+						item1=2545;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+				};
+			};
+			id=2394;
+			atlOffset=0.35728931;
+		};
+		class Item79
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2420.438,5.0114393,952.69604};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+					};
+					id=2538;
+					type="O_helipilot_F";
+					atlOffset=0.010000229;
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2420.438,5.0114393,952.69604};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+					};
+					id=2539;
+					type="O_helipilot_F";
+					atlOffset=0.010000229;
+				};
+			};
+			class Attributes
+			{
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=2;
+				};
+				class Links
+				{
+					items=2;
+					class Item0
+					{
+						linkID=0;
+						item0=2538;
+						item1=2537;
+						class CustomData
+						{
+							role=1;
+						};
+					};
+					class Item1
+					{
+						linkID=1;
+						item0=2539;
+						item1=2537;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+				};
+			};
+			id=2397;
+			atlOffset=0.010000229;
+		};
+		class Item80
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={2419.0068,5.8319387,935.28882};
+			};
+			id=2401;
+			type="SupportRequester";
+			atlOffset=0.83193874;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="SupportRequester_BIS_SUPP_limit_UAV";
+					expression="_this setVariable ['BIS_SUPP_limit_UAV',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="SupportRequester_BIS_SUPP_custom_HQ";
+					expression="_this setVariable ['BIS_SUPP_custom_HQ',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="SupportRequester_BIS_SUPP_limit_Transport";
+					expression="_this setVariable ['BIS_SUPP_limit_Transport',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				class Attribute3
+				{
+					property="SupportRequester_BIS_SUPP_limit_Drop";
+					expression="_this setVariable ['BIS_SUPP_limit_Drop',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				class Attribute4
+				{
+					property="SupportRequester_BIS_SUPP_limit_CAS_Heli";
+					expression="_this setVariable ['BIS_SUPP_limit_CAS_Heli',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				class Attribute5
+				{
+					property="SupportRequester_BIS_SUPP_limit_Artillery";
+					expression="_this setVariable ['BIS_SUPP_limit_Artillery',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				class Attribute6
+				{
+					property="SupportRequester_BIS_SUPP_limit_CAS_Bombing";
+					expression="_this setVariable ['BIS_SUPP_limit_CAS_Bombing',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="-1";
+						};
+					};
+				};
+				nAttributes=7;
+			};
+		};
+		class Item81
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=1;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2416.9512,5.7404861,930.1438};
+					};
+					side="East";
+					flags=2;
+					class Attributes
+					{
+					};
+					id=2544;
+					type="O_G_Soldier_F";
+					atlOffset=0.73904705;
+				};
+			};
+			class Attributes
+			{
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=1;
+				};
+				class Links
+				{
+					items=1;
+					class Item0
+					{
+						linkID=0;
+						item0=2544;
+						item1=2543;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+				};
+			};
+			id=2402;
+			atlOffset=0.73904705;
+		};
+		class Item82
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2421.3159,5.2114391,928.89996};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+					};
+					id=2541;
+					type="O_helipilot_F";
+					atlOffset=0.21000004;
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2421.3159,5.2114391,928.89996};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+					};
+					id=2542;
+					type="O_helipilot_F";
+					atlOffset=0.21000004;
+				};
+			};
+			class Attributes
+			{
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=2;
+				};
+				class Links
+				{
+					items=2;
+					class Item0
+					{
+						linkID=0;
+						item0=2541;
+						item1=2540;
+						class CustomData
+						{
+							role=1;
+						};
+					};
+					class Item1
+					{
+						linkID=1;
+						item0=2542;
+						item1=2540;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+				};
+			};
+			id=2405;
+			atlOffset=0.21000004;
+		};
+		class Item83
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=4;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2434.7751,5.0014391,961.54614};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="COLONEL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""co"",this,""spetsnaz""] call f_fnc_assignGear;";
+						name="UnitNPR_CO";
+						description="Spetsnaz Commander";
+						isPlayer=1;
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2547;
+					type="O_G_officer_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male01GRE";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1.05;
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2439.7749,5.0014391,959.89478};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""jtac"",this] call f_fnc_assignGear;";
+						name="UnitNPR_CO_JTAC";
+						description="NPR JTAC";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2410;
+					type="O_G_officer_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male02GRE";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=0.95999998;
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2430.3057,5.0014391,958.53394};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""uav"",this] call f_fnc_assignGear;";
+						name="UnitNPR_CO_UAV";
+						description="NPR UAV Operator";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2411;
+					type="O_G_Soldier_F";
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2444.7754,5.0014391,957.15503};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""m"",this] call f_fnc_assignGear;";
+						name="UnitNPR_CO_M";
+						description="NPR Medic";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2412;
+					type="O_G_medic_F";
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_CO";
+			};
+			id=2409;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR CO -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item84
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=4;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2434.2373,5.2133446,937.1814};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="MAJOR";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""dc"",this] call f_fnc_assignGear;";
+						name="UnitNPR_DC";
+						description="NPR Deputy Commander";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2415;
+					type="O_G_officer_F";
+					atlOffset=0.21190548;
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1.04;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2439.2373,5.2344303,935.53101};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""jtac"",this] call f_fnc_assignGear;";
+						name="UnitNPR_DC_JTAC";
+						description="NPR Forward Observer";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2416;
+					type="O_G_officer_F";
+					atlOffset=0.23299122;
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=0.94999999;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2429.2373,5.1082706,935.53101};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""uav"",this] call f_fnc_assignGear;";
+						name="UnitNPR_DC_UAV";
+						description="NPR UAV Operator";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2417;
+					type="O_G_Soldier_F";
+					atlOffset=0.10683155;
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1.03;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2444.2373,5.1013861,932.79175};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""m"",this] call f_fnc_assignGear;";
+						name="UnitNPR_DC_M";
+						description="NPR Medic";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2418;
+					type="O_G_medic_F";
+					atlOffset=0.099946976;
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=0.94999999;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_DC";
+			};
+			id=2414;
+			atlOffset=0.21190548;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR DC -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item85
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2470.9287,5.0014391,960.93652};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CAPTAIN";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""dc"",this,""spetsnaz""] call f_fnc_assignGear;";
+						name="UnitNPR_ASL_SL";
+						description="Spetsnaz Alpha Squad Leader";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2420;
+					type="O_G_Soldier_SL_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male01GRE";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1.05;
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2475.9287,5.0014391,959.28589};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""m"",this] call f_fnc_assignGear;";
+						name="UnitNPR_ASL_M";
+						description="NPR Alpha Medic";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2421;
+					type="O_G_medic_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_ASL";
+			};
+			id=2419;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR ASL -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item86
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=6;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2471.4883,5.0014391,939.4314};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="LIEUTENANT";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""FTL"",this] call f_fnc_assignGear;";
+						name="UnitNPR_A1_FTL";
+						description="NPR Alpha 1 Fire Team Leader";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2423;
+					type="O_G_Soldier_TL_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1.02;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2476.4883,5.0913763,937.78101};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""ar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_A1_AR1";
+						description="NPR Alpha 1 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2424;
+					type="O_G_Soldier_AR_F";
+					atlOffset=0.08993721;
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1.03;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2466.4883,5.0014391,937.78101};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""ar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_A1_AR2";
+						description="NPR Alpha 1 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2425;
+					type="O_G_Soldier_AR_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2481.4883,5.248991,935.04175};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""rat"",this] call f_fnc_assignGear;";
+						name="UnitNPR_A1_AT";
+						description="NPR Alpha 1 Assaultman (AT)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2426;
+					type="O_G_Soldier_LAT_F";
+					atlOffset=0.24755192;
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1.01;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2461.4883,5.0014391,935.04175};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""aar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_A1_R1";
+						description="NPR Alpha 1 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2427;
+					type="O_G_Soldier_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1.04;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2486.4883,5.0014391,930.49487};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""aar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_A1_R2";
+						description="NPR Alpha 1 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2428;
+					type="O_G_Soldier_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1.03;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_A1";
+			};
+			id=2422;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR A1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item87
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=6;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2471.252,5.0014391,915.55249};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="LIEUTENANT";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""FTL"",this] call f_fnc_assignGear;";
+						name="UnitNPR_A2_FTL";
+						description="NPR Alpha 2 Fire Team Leader";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2430;
+					type="O_G_Soldier_TL_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1.04;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2476.252,5.0014391,913.9021};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""ar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_A2_AR1";
+						description="NPR Alpha 2 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2431;
+					type="O_G_Soldier_AR_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=0.97000003;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2466.252,5.0014391,913.9021};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""ar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_A2_AR2";
+						description="NPR Alpha 2 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2432;
+					type="O_G_Soldier_AR_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1.01;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2481.252,5.0014391,911.16284};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""rat"",this] call f_fnc_assignGear;";
+						name="UnitNPR_A2_AT";
+						description="NPR Alpha 2 Assaultman (AT)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2433;
+					type="O_G_Soldier_LAT_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1.03;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2461.252,5.0014391,911.16284};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""aar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_A2_R1";
+						description="NPR Alpha 2 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2434;
+					type="O_G_Soldier_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1.03;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2486.252,5.0014391,906.61597};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""aar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_A2_R2";
+						description="NPR Alpha 2 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2435;
+					type="O_G_Soldier_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=0.97000003;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_A2";
+			};
+			id=2429;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR A2 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item88
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2511.6108,5.0014391,960.8894};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CAPTAIN";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""dc"",this,""spetsnaz""] call f_fnc_assignGear;";
+						name="UnitNPR_BSL_SL";
+						description="Spetsnaz Bravo Squad Leader";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2437;
+					type="O_G_Soldier_SL_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male02GRE";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1.01;
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2516.6104,5.0014391,959.23901};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""m"",this] call f_fnc_assignGear;";
+						name="UnitNPR_BSL_M";
+						description="NPR Bravo Medic";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2438;
+					type="O_G_medic_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1.02;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_BSL";
+			};
+			id=2436;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR BSL -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item89
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=6;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2512.377,5.0014391,939.19409};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="LIEUTENANT";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""FTL"",this] call f_fnc_assignGear;";
+						name="UnitNPR_B1_FTL";
+						description="NPR Bravo 1 Fire Team Leader";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2440;
+					type="O_G_Soldier_TL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2517.377,5.0014391,937.54468};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""ar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_B1_AR1";
+						description="NPR Bravo 1 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2441;
+					type="O_G_Soldier_AR_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1.01;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2507.377,5.0014391,937.54468};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""ar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_B1_AR2";
+						description="NPR Bravo 1 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2442;
+					type="O_G_Soldier_AR_F";
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2522.377,5.0014391,934.80444};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""rat"",this] call f_fnc_assignGear;";
+						name="UnitNPR_B1_AT";
+						description="NPR Bravo 1 Assaultman (AT)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2443;
+					type="O_G_Soldier_LAT_F";
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2502.377,5.0014391,934.80444};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""aar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_B1_R1";
+						description="NPR Bravo 1 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2444;
+					type="O_G_Soldier_F";
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2527.377,5.0014391,930.25854};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""aar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_B1_R2";
+						description="NPR Bravo 1 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2445;
+					type="O_G_Soldier_F";
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_B1";
+			};
+			id=2439;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR B1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item90
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=6;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2511.8174,5.0014391,915.96655};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="LIEUTENANT";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""FTL"",this] call f_fnc_assignGear;";
+						name="UnitNPR_B2_FTL";
+						description="NPR Bravo 2 Fire Team Leader";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2447;
+					type="O_G_Soldier_TL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2516.8174,5.0014391,914.31519};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""ar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_B2_AR1";
+						description="NPR Bravo 2 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2448;
+					type="O_G_Soldier_AR_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2506.8174,5.0014391,914.31519};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""ar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_B2_AR2";
+						description="NPR Bravo 2 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2449;
+					type="O_G_Soldier_AR_F";
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2521.8174,5.0014391,911.57593};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""rat"",this] call f_fnc_assignGear;";
+						name="UnitNPR_B2_AT";
+						description="NPR Bravo 2 Assaultman (AT)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2450;
+					type="O_G_Soldier_LAT_F";
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2501.8174,5.0014391,911.57593};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""aar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_B2_R1";
+						description="NPR Bravo 2 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2451;
+					type="O_G_Soldier_F";
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2526.8174,5.0014391,907.02905};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""aar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_B2_R2";
+						description="NPR Bravo 2 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2452;
+					type="O_G_Soldier_F";
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_B2";
+			};
+			id=2446;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR B2 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item91
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2554.7935,5.3024392,960.29248};
+					};
+					side="East";
+					flags=2;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CAPTAIN";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""dc"",this,""spetsnaz""] call f_fnc_assignGear;";
+						name="UnitNPR_CSL_SL";
+						description="Spetsnaz Charlie Squad Leader";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2454;
+					type="O_G_Soldier_SL_F";
+					atlOffset=0.30100012;
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male05GRE";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=0.95999998;
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2559.7939,5.6464462,958.64233};
+					};
+					side="East";
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""m"",this] call f_fnc_assignGear;";
+						name="UnitNPR_CSL_M";
+						description="NPR Charlie Medic";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2455;
+					type="O_G_medic_F";
+					atlOffset=0.64500713;
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_CSL";
+			};
+			id=2453;
+			atlOffset=0.30100012;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR CSL -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item92
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=6;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2555.1953,5.0014391,938.53296};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="LIEUTENANT";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""FTL"",this] call f_fnc_assignGear;";
+						name="UnitNPR_C1_FTL";
+						description="NPR Charlie 1 Fire Team Leader";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2457;
+					type="O_G_Soldier_TL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2560.1953,5.0014391,936.88354};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""ar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_C1_AR1";
+						description="NPR Charlie 1 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2458;
+					type="O_G_Soldier_AR_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2550.1953,5.0014391,936.88354};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""ar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_C1_AR2";
+						description="NPR Charlie 1 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2459;
+					type="O_G_Soldier_AR_F";
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2565.1953,5.0014391,934.14331};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""rat"",this] call f_fnc_assignGear;";
+						name="UnitNPR_C1_AT";
+						description="NPR Charlie 1 Assaultman (AT)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2460;
+					type="O_G_Soldier_LAT_F";
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2545.1953,5.0014391,934.14331};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""aar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_C1_R1";
+						description="NPR Charlie 1 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2461;
+					type="O_G_Soldier_F";
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2570.1953,5.0014391,929.59644};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""aar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_C1_R2";
+						description="NPR Charlie 1 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2462;
+					type="O_G_Soldier_F";
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_C1";
+			};
+			id=2456;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR C1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item93
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=6;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2555.5,5.0014391,915.42944};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="LIEUTENANT";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""FTL"",this] call f_fnc_assignGear;";
+						name="UnitNPR_C2_FTL";
+						description="NPR Charlie 2 Fire Team Leader";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2464;
+					type="O_G_Soldier_TL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2560.5,5.0014391,913.77905};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""ar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_C2_AR1";
+						description="NPR Charlie 2 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2465;
+					type="O_G_Soldier_AR_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2550.5,5.0014391,913.77905};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""ar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_C2_AR2";
+						description="NPR Charlie 2 Automatic Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2466;
+					type="O_G_Soldier_AR_F";
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2565.5,5.0014391,911.03979};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""rat"",this] call f_fnc_assignGear;";
+						name="UnitNPR_C2_AT";
+						description="NPR Charlie 2 Assaultman (AT)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2467;
+					type="O_G_Soldier_LAT_F";
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2545.5,5.0014391,911.03979};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""aar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_C2_R1";
+						description="NPR Charlie 2 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2468;
+					type="O_G_Soldier_F";
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2570.5,5.0014391,906.49194};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""aar"",this] call f_fnc_assignGear;";
+						name="UnitNPR_C2_R2";
+						description="NPR Charlie 2 Rifleman";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2469;
+					type="O_G_Soldier_F";
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_C2";
+			};
+			id=2463;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR C2 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item94
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=3;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2591.4854,5.153439,960.51416};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""mmgl"",this] call f_fnc_assignGear;";
+						name="UnitNPR_MMG1_TL";
+						description="NPR Medium MG Team 1 Spotter (Leader)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2471;
+					type="O_G_Soldier_TL_F";
+					atlOffset=0.15199995;
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2596.4854,5.2476587,958.86401};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""mmgg"",this] call f_fnc_assignGear;";
+						name="UnitNPR_MMG1_G";
+						description="NPR Medium MG Team 1 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2472;
+					type="O_G_Soldier_AR_F";
+					atlOffset=0.24621964;
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2587.3232,5.153439,958.89331};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""mmgag"",this] call f_fnc_assignGear;";
+						name="UnitNPR_MMG1_AG";
+						description="NPR Medium MG Team 1 Assistant";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2473;
+					type="O_G_Soldier_lite_F";
+					atlOffset=0.15199995;
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_MMG1";
+			};
+			id=2470;
+			atlOffset=0.15199995;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR MMG1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item95
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=3;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2591.3452,5.0014391,949.17505};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""mmgl"",this] call f_fnc_assignGear;";
+						name="UnitNPR_MMG2_TL";
+						description="NPR Medium MG Team 2 Spotter (Leader)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2475;
+					type="O_G_Soldier_TL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2596.3457,5.0014391,947.52515};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""mmgg"",this] call f_fnc_assignGear;";
+						name="UnitNPR_MMG2_G";
+						description="NPR Medium MG Team 2 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2476;
+					type="O_G_Soldier_AR_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2587.1831,5.0014391,947.5542};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""mmgag"",this] call f_fnc_assignGear;";
+						name="UnitNPR_MMG2_AG";
+						description="NPR Medium MG Team 2 Assistant";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2477;
+					type="O_G_Soldier_lite_F";
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_MMG2";
+			};
+			id=2474;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR MMG2 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item96
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=3;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2591.6895,5.0014391,938.46704};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""matl"",this] call f_fnc_assignGear;      ";
+						name="UnitNPR_MAT1_TL";
+						description="NPR Medium AT Team 1 Spotter (Leader)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2479;
+					type="O_G_Soldier_TL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2596.6895,5.0014391,936.81714};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""matg"",this] call f_fnc_assignGear; ";
+						name="UnitNPR_MAT1_G";
+						description="NPR Medium AT Team 1 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2480;
+					type="O_G_Soldier_LAT_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2587.5273,5.0014391,936.84619};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""matag"",this] call f_fnc_assignGear;      ";
+						name="UnitNPR_MAT1_AG";
+						description="NPR Medium AT Team 1 Assistant";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2481;
+					type="O_G_Soldier_LAT_F";
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_MAT1";
+			};
+			id=2478;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR MAT1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item97
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=3;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2591.6021,5.0014391,926.48511};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""matl"",this] call f_fnc_assignGear; ";
+						name="UnitNPR_MAT2_TL";
+						description="NPR Medium AT Team 2 Spotter (Leader)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2483;
+					type="O_G_Soldier_TL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2596.6025,5.0014391,924.83472};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						health=0.99000001;
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""matg"",this] call f_fnc_assignGear; ";
+						name="UnitNPR_MAT2_G";
+						description="NPR Medium AT Team 2 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2484;
+					type="O_G_Soldier_LAT_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2587.4404,5.0014391,924.86304};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""matag"",this] call f_fnc_assignGear; ";
+						name="UnitNPR_MAT2_AG";
+						description="NPR Medium AT Team 2 Assistant";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2485;
+					type="O_G_Soldier_LAT_F";
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_MAT2";
+			};
+			id=2482;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR MAT2 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item98
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2592.0908,5.0014391,915.58667};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""hmgag"",this] call f_fnc_assignGear;      ";
+						name="UnitNPR_HMG1_TL";
+						description="NPR Heavy MG Team 1 Spotter (Leader)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2487;
+					type="O_G_Soldier_TL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2597.0908,5.0014391,913.93628};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""hmgg"",this] call f_fnc_assignGear; ";
+						name="UnitNPR_HMG1_G";
+						description="NPR Heavy MG Team 1 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2488;
+					type="O_G_Soldier_AR_F";
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_HMG1";
+			};
+			id=2486;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR HMG1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item99
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=3;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2591.915,5.0014391,903.18335};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""hatl"",this] call f_fnc_assignGear; ";
+						name="UnitNPR_HAT1_TL";
+						description="NPR Heavy AT Team 1 Spotter (Leader)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2490;
+					type="O_G_Soldier_TL_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2596.915,5.2301273,901.53296};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						health=0.99000001;
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""hatg"",this] call f_fnc_assignGear; ";
+						name="UnitNPR_HAT1_G";
+						description="NPR Heavy AT Team 1 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2491;
+					type="O_G_Soldier_LAT_F";
+					atlOffset=0.22868824;
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2587.752,5.0014391,901.56128};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""hatag"",this] call f_fnc_assignGear; ";
+						name="UnitNPR_HAT1_AG";
+						description="NPR Heavy AT Team 1 Assistant";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2492;
+					type="O_G_Soldier_LAT_F";
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_HAT1";
+			};
+			id=2489;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR HAT1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item100
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2591.917,5.0014391,891.41479};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""mtrag"",this] call f_fnc_assignGear; ";
+						name="UnitNPR_MTR1_TL";
+						description="NPR Mortar Team 1 Spotter (Leader)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2494;
+					type="O_G_Soldier_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2596.917,5.3897858,889.7644};
+					};
+					side="East";
+					class Attributes
+					{
+						health=0.99000001;
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""mtrg"",this] call f_fnc_assignGear; ";
+						name="UnitNPR_MTR1_G";
+						description="NPR Mortar Team 1 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2495;
+					type="O_G_Soldier_A_F";
+					atlOffset=0.38834667;
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_MTR1";
+			};
+			id=2493;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR MTR1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item101
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=3;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2591.916,5.0014391,878.89722};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""msaml"",this] call f_fnc_assignGear; ";
+						name="UnitNPR_MSAM1_TL";
+						description="NPR Medium SAM Team 1 Spotter (Leader)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2497;
+					type="O_G_Soldier_LAT_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2596.916,5.5413675,877.24683};
+					};
+					side="East";
+					class Attributes
+					{
+						health=0.99000001;
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""msamg"",this] call f_fnc_assignGear; ";
+						name="UnitNPR_MSAM1_G";
+						description="NPR Medium SAM Team 1 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2498;
+					type="O_G_Soldier_LAT_F";
+					atlOffset=0.53992844;
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2587.7529,5.0014391,877.27515};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""msamag"",this] call f_fnc_assignGear; ";
+						name="UnitNPR_MSAM1_AG";
+						description="NPR Medium SAM Team 1 Assistant";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2499;
+					type="O_G_Soldier_LAT_F";
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_MSAM1";
+			};
+			id=2496;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR MSAM1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item102
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2591.8154,5.0014391,866.1228};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""hsamag"",this] call f_fnc_assignGear; ";
+						name="UnitNPR_HSAM1_TL";
+						description="NPR Heavy SAM Team 1 Spotter (Leader)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2501;
+					type="O_G_Soldier_LAT_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2596.8154,5.0014391,864.47241};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						health=0.99000001;
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""hsamg"",this] call f_fnc_assignGear; ";
+						name="UnitNPR_HSAM1_G";
+						description="NPR Heavy SAM Team 1 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2502;
+					type="O_G_Soldier_LAT_F";
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_HSAM1";
+			};
+			id=2500;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR HSAM1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item103
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2591.6885,5.0014391,855.21753};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""sp"",this] call f_fnc_assignGear; ";
+						name="UnitNPR_ST1_SP";
+						description="NPR Sniper Team 1 Spotter (Leader)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2504;
+					type="O_G_Soldier_M_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2596.6885,5.0014391,853.56714};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						health=0.99000001;
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""sn"",this] call f_fnc_assignGear; ";
+						name="UnitNPR_ST1_G";
+						description="NPR Sniper Team 1 Sniper";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2505;
+					type="O_G_Soldier_M_F";
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_ST1";
+			};
+			id=2503;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR ST1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item104
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=4;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2592.46,5.0014391,842.87085};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""eng"",this] call f_fnc_assignGear;";
+						name="UnitNPR_ENG1_FTL";
+						description="NPR Engineer Team 1 Leader (Demo)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2507;
+					type="O_G_engineer_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2597.46,5.0014391,841.22046};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""eng"",this] call f_fnc_assignGear;";
+						name="UnitNPR_ENG1_A1";
+						description="NPR Engineer Team 1 Assistant (Demo)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2508;
+					type="O_G_engineer_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2587.46,5.0014391,841.22046};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""engm"",this] call f_fnc_assignGear;";
+						name="UnitNPR_ENG1_A2";
+						description="NPR Engineer Team 1 Assistant (Mines)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2509;
+					type="O_G_engineer_F";
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2602.46,5.0014391,838.4812};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""engm"",this] call f_fnc_assignGear;";
+						name="UnitNPR_ENG1_A3";
+						description="NPR Engineer Team 1 Assistant (Mines)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2510;
+					type="O_G_engineer_F";
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_ENG1";
+			};
+			id=2506;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR ENG1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item105
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2438.377,5.0014391,877.57196};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""vd"",this] call f_fnc_assignGear;";
+						name="UnitNPR_IFV1_D";
+						description="NPR Technical 1 Driver (Repair)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2512;
+					type="O_G_Soldier_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2438.377,5.0014391,877.57196};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""vg"",this] call f_fnc_assignGear;";
+						name="UnitNPR_IFV1_G";
+						description="NPR Technical 1 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2513;
+					type="O_G_Soldier_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_IFV1";
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=2;
+				};
+				class Links
+				{
+					items=2;
+					class Item0
+					{
+						linkID=0;
+						item0=2512;
+						item1=2514;
+						class CustomData
+						{
+							role=1;
+						};
+					};
+					class Item1
+					{
+						linkID=1;
+						item0=2513;
+						item1=2514;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+				};
+			};
+			id=2511;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR TECH1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item106
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2438.377,7.1644082,877.56329};
+			};
+			side="East";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[this,""npr""] call f_fnc_setVirtualFaction; [""v_ifv"",this] call f_fnc_assignGear";
+				name="VehNPR_IFV1";
+				textures="Guerilla_07";
+			};
+			id=2514;
+			type="O_G_Offroad_01_armed_F";
+		};
+		class Item107
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2473.1011,5.0014391,877.48901};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="CORPORAL";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""vg"",this] call f_fnc_assignGear;";
+						name="UnitNPR_IFV2_G";
+						description="NPR Technical 2 Gunner";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2516;
+					type="O_G_Soldier_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=0.99833667;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2473.1011,5.0014391,877.48901};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""vd"",this] call f_fnc_assignGear;";
+						name="UnitNPR_IFV2_D";
+						description="NPR Technical 2 Driver (Repair)";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2517;
+					type="O_G_Soldier_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_IFV2";
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=2;
+				};
+				class Links
+				{
+					items=2;
+					class Item0
+					{
+						linkID=0;
+						item0=2516;
+						item1=2518;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+					class Item1
+					{
+						linkID=1;
+						item0=2517;
+						item1=2518;
+						class CustomData
+						{
+							role=1;
+						};
+					};
+				};
+			};
+			id=2515;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR TECH2 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item108
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2473.1011,7.1644082,877.48035};
+			};
+			side="East";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[this,""npr""] call f_fnc_setVirtualFaction; [""v_ifv"",this] call f_fnc_assignGear";
+				name="VehNPR_IFV2";
+				textures="Guerilla_07";
+			};
+			id=2518;
+			type="O_G_Offroad_01_armed_F";
+		};
+		class Item109
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={2416.9121,5.8610754,932.96362};
+			};
+			id=2519;
+			type="SupportProvider_Artillery";
+			atlOffset=0.8610754;
+		};
+		class Item110
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={2462.1133,5,980.48608};
+			};
+			name="F3_preMount_NPR_5";
+			init="[synchronizedObjects this, [""grpNPR_ASL"",""grpNPR_A1"",""grpNPR_A2""], true, false] call f_fnc_mountGroups;";
+			id=2520;
+			type="Logic";
+		};
+		class Item111
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={2505.7476,5,982.57349};
+			};
+			name="F3_preMount_NPR_6";
+			init="[synchronizedObjects this, [""grpNPR_BSL"",""grpNPR_B1"",""grpNPR_B2""], true, false] call f_fnc_mountGroups;";
+			id=2521;
+			type="Logic";
+		};
+		class Item112
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={2547.1201,5,984.74316};
+			};
+			name="F3_preMount_NPR_7";
+			init="[synchronizedObjects this, [""grpNPR_CSL"",""grpNPR_C1"",""grpNPR_C2""], true, false] call f_fnc_mountGroups;";
+			id=2522;
+			type="Logic";
+		};
+		class Item113
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={2424.0928,5,974.83545};
+			};
+			name="F3_preMount_NPR_8";
+			init="[synchronizedObjects this, [""grpNPR_CO""], true, false] call f_fnc_mountGroups;";
+			id=2523;
+			type="Logic";
+		};
+		class Item114
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={2425.5508,5,949.01196};
+			};
+			name="F3_preMount_NPR_9";
+			init="[synchronizedObjects this, [""grpNPR_DC""], true, false] call f_fnc_mountGroups;";
+			id=2524;
+			type="Logic";
+		};
+		class Item115
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2604.9854,6.6115026,930.93628};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[this,""npr""] call f_fnc_setVirtualFaction; [""v_car"",this] call f_fnc_assignGear";
+				name="VehNPR_CAR4";
+				textures="Guerilla_07";
+			};
+			id=2525;
+			type="O_G_Offroad_01_F";
+		};
+		class Item116
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2429.0674,6.6115026,962.24976};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[this,""npr""] call f_fnc_setVirtualFaction; [""v_car"",this] call f_fnc_assignGear";
+				name="VehNPR_CAR1";
+				textures="Guerilla_07";
+			};
+			id=2526;
+			type="O_G_Offroad_01_F";
+		};
+		class Item117
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2429.1465,6.7971687,939.72729};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[this,""npr""] call f_fnc_setVirtualFaction; [""v_car"",this] call f_fnc_assignGear";
+				name="VehNPR_CAR2";
+				textures="Guerilla_07";
+			};
+			id=2527;
+			type="O_G_Offroad_01_F";
+			atlOffset=0.18566608;
+		};
+		class Item118
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2604.2197,6.6115026,953.50366};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[this,""npr""] call f_fnc_setVirtualFaction; [""v_car"",this] call f_fnc_assignGear";
+				name="VehNPR_CAR3";
+				textures="Guerilla_07";
+			};
+			id=2528;
+			type="O_G_Offroad_01_F";
+		};
+		class Item119
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2470.4519,6.8715067,976.32617};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[this,""npr""] call f_fnc_setVirtualFaction; [""v_tr"",this] call f_fnc_assignGear";
+				name="VehNPR_TR1";
+				textures="Guerilla_04";
+			};
+			id=2529;
+			type="O_G_Van_01_transport_F";
+		};
+		class Item120
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2478.3496,6.8716264,971.83276};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[this,""npr""] call f_fnc_setVirtualFaction; [""v_tr"",this] call f_fnc_assignGear";
+				name="VehNPR_TR2";
+				textures="Guerilla_04";
+			};
+			id=2530;
+			type="O_G_Van_01_transport_F";
+			atlOffset=0.00011968613;
+		};
+		class Item121
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2514.3623,6.8716264,977.11401};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[this,""npr""] call f_fnc_setVirtualFaction; [""v_tr"",this] call f_fnc_assignGear";
+				name="VehNPR_TR3";
+				textures="Guerilla_04";
+			};
+			id=2531;
+			type="O_G_Van_01_transport_F";
+			atlOffset=0.00011968613;
+		};
+		class Item122
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2524.4727,6.8716264,971.95776};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[this,""npr""] call f_fnc_setVirtualFaction; [""v_tr"",this] call f_fnc_assignGear";
+				name="VehNPR_TR4";
+				textures="Guerilla_04";
+			};
+			id=2532;
+			type="O_G_Van_01_transport_F";
+			atlOffset=0.00011968613;
+		};
+		class Item123
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2554.8184,6.8716264,976.95972};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[this,""npr""] call f_fnc_setVirtualFaction; [""v_tr"",this] call f_fnc_assignGear";
+				name="VehNPR_TR5";
+				textures="Guerilla_04";
+			};
+			id=2533;
+			type="O_G_Van_01_transport_F";
+			atlOffset=0.00011968613;
+		};
+		class Item124
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2563.6807,6.8716264,971.45093};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[this,""npr""] call f_fnc_setVirtualFaction; [""v_tr"",this] call f_fnc_assignGear";
+				name="VehNPR_TR6";
+				textures="Guerilla_04";
+			};
+			id=2534;
+			type="O_G_Van_01_transport_F";
+			atlOffset=0.00011968613;
+		};
+		class Item125
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={2421.502,5.7177486,933.42065};
+			};
+			id=2535;
+			type="SupportProvider_Virtual_CAS_Heli";
+			atlOffset=0.71774864;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_cooldown";
+					expression="_this setVariable ['BIS_SUPP_cooldown',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"SCALAR"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicleInit";
+					expression="_this setVariable ['BIS_SUPP_vehicleInit',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicles";
+					expression="_this setVariable ['BIS_SUPP_vehicles',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[]";
+						};
+					};
+				};
+				class Attribute3
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_filter";
+					expression="_this setVariable ['BIS_SUPP_filter',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Side";
+						};
+					};
+				};
+				nAttributes=4;
+			};
+		};
+		class Item126
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={2420.3564,5.4597912,956.698};
+			};
+			id=2536;
+			type="SupportProvider_Virtual_CAS_Heli";
+			atlOffset=0.45979118;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_cooldown";
+					expression="_this setVariable ['BIS_SUPP_cooldown',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"SCALAR"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicleInit";
+					expression="_this setVariable ['BIS_SUPP_vehicleInit',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicles";
+					expression="_this setVariable ['BIS_SUPP_vehicles',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[]";
+						};
+					};
+				};
+				class Attribute3
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_filter";
+					expression="_this setVariable ['BIS_SUPP_filter',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Side";
+						};
+					};
+				};
+				nAttributes=4;
+			};
+		};
+		class Item127
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2420.438,7.1796465,952.5354};
+			};
+			side="East";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[this,""npr""] call f_fnc_setVirtualFaction; ";
+				textures="Black";
+				receiveRemoteTargets=1;
+			};
+			id=2537;
+			type="O_Heli_Light_02_dynamicLoadout_F";
+			atlOffset=0.010000229;
+		};
+		class Item128
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2421.3159,7.3796463,928.73932};
+			};
+			side="East";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[this,""npr""] call f_fnc_setVirtualFaction; ";
+				textures="Black";
+				receiveRemoteTargets=1;
+			};
+			id=2540;
+			type="O_Heli_Light_02_dynamicLoadout_F";
+			atlOffset=0.21000004;
+		};
+		class Item129
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2416.9512,6.4606729,930.09351};
+			};
+			side="East";
+			flags=2;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[this,""npr""] call f_fnc_setVirtualFaction; ";
+			};
+			id=2543;
+			type="O_G_Mortar_01_F";
+			atlOffset=0.73904705;
+		};
+		class Item130
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2416.0908,6.0789151,953.86987};
+			};
+			side="East";
+			flags=2;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[this,""npr""] call f_fnc_setVirtualFaction; ";
+			};
+			id=2545;
+			type="O_G_Mortar_01_F";
+			atlOffset=0.35728931;
+		};
+		class Item131
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2593,5.6047058,830.01996};
+			};
+			side="East";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[this,""npr""] call f_fnc_setVirtualFaction; [""v_helo_l"",this] call f_fnc_assignGear";
+				name="VehNPR_TH1";
+				textures="Elliptical";
+			};
+			id=2392;
+			type="C_Heli_Light_01_civil_F";
+		};
+		class Item132
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2593,5.0014391,831.04999};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="LIEUTENANT";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""pc"",this] call f_fnc_assignGear;";
+						name="UnitNPR_TH1_P";
+						description="NPR Transport Helo 1 Pilot";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2390;
+					type="O_G_engineer_F";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={2593,5.0014391,831.04999};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						skill=0.60000002;
+						rank="SERGEANT";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""pc"",this] call f_fnc_assignGear;";
+						name="UnitNPR_TH1_CP";
+						description="NPR Transport Helo 1 Co-Pilot";
+						isPlayable=1;
+						reportRemoteTargets=1;
+					};
+					id=2391;
+					type="O_G_engineer_F";
+				};
+			};
+			class Attributes
+			{
+				name="grpNPR_TH1";
+			};
+			class CrewLinks
+			{
+				class LinkIDProvider
+				{
+					nextID=2;
+				};
+				class Links
+				{
+					items=2;
+					class Item0
+					{
+						linkID=0;
+						item0=2390;
+						item1=2392;
+						class CustomData
+						{
+							role=1;
+						};
+					};
+					class Item1
+					{
+						linkID=1;
+						item0=2391;
+						item1=2392;
+						class CustomData
+						{
+							role=2;
+							turretPath[]={0};
+						};
+					};
+				};
+			};
+			id=2389;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NPR TH1 -";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item133
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={432.07501,8.3443718,1248.3247};
 			};
 			side="West";
 			flags=6;
@@ -320,15 +11407,15 @@ class Mission
 				init="[""v_helo_h"",this] call f_fnc_assignGear";
 				name="VehNATO_TH1";
 			};
-			id=0;
+			id=2551;
 			type="B_Heli_Transport_03_F";
 		};
-		class Item1
+		class Item134
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={2379.1594,7.5924172,1254.5444};
+				position[]={2379.1589,7.5924172,1254.5443};
 			};
 			side="East";
 			flags=6;
@@ -339,15 +11426,15 @@ class Mission
 				name="VehCSAT_TH1";
 				textures="Opfor";
 			};
-			id=1;
+			id=2552;
 			type="O_Heli_Transport_04_covered_F";
 		};
-		class Item2
+		class Item135
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1409.0298,8.5861206,617.8595};
+				position[]={1381.799,8.610199,1218.4109};
 			};
 			side="Independent";
 			flags=6;
@@ -357,16 +11444,15 @@ class Mission
 				init="[""v_helo_h"",this] call f_fnc_assignGear";
 				name="VehAAF_TH1";
 			};
-			id=2;
+			id=2553;
 			type="I_Heli_Transport_02_F";
-			atlOffset=-0.024078369;
 		};
-		class Item3
+		class Item136
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={432.47964,8.3443718,1220.5431};
+				position[]={432.48001,8.3443718,1220.5427};
 			};
 			side="West";
 			flags=6;
@@ -377,15 +11463,15 @@ class Mission
 				name="VehNATO_TH2";
 				textures="Green";
 			};
-			id=3;
+			id=2554;
 			type="B_Heli_Transport_03_F";
 		};
-		class Item4
+		class Item137
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={467.55972,7.1392474,1249.049};
+				position[]={467.56,7.1392598,1249.0493};
 			};
 			side="West";
 			flags=6;
@@ -396,16 +11482,15 @@ class Mission
 				name="VehNATO_TH3";
 				textures="Green";
 			};
-			id=4;
+			id=2555;
 			type="B_Heli_Transport_01_F";
-			atlOffset=-1.2397766e-005;
 		};
-		class Item5
+		class Item138
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={468.41714,7.1392474,1221.5109};
+				position[]={468.41699,7.1392598,1221.5104};
 			};
 			side="West";
 			flags=6;
@@ -416,16 +11501,15 @@ class Mission
 				name="VehNATO_TH4";
 				textures="Green";
 			};
-			id=5;
+			id=2556;
 			type="B_Heli_Transport_01_F";
-			atlOffset=-1.2397766e-005;
 		};
-		class Item6
+		class Item139
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={516.71497,7.1392474,1249.255};
+				position[]={516.71503,7.1392598,1249.2554};
 			};
 			side="West";
 			flags=6;
@@ -436,16 +11520,15 @@ class Mission
 				name="VehNATO_TH5";
 				textures="Green";
 			};
-			id=6;
+			id=2557;
 			type="B_Heli_Transport_01_F";
-			atlOffset=-1.2397766e-005;
 		};
-		class Item7
+		class Item140
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={516.78723,7.1392474,1221.2482};
+				position[]={516.78699,7.1392598,1221.2484};
 			};
 			side="West";
 			flags=6;
@@ -456,16 +11539,15 @@ class Mission
 				name="VehNATO_TH6";
 				textures="Green";
 			};
-			id=7;
+			id=2558;
 			type="B_Heli_Transport_01_F";
-			atlOffset=-1.2397766e-005;
 		};
-		class Item8
+		class Item141
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={562.33704,7.1392474,1249.8331};
+				position[]={562.33698,7.1392598,1249.8334};
 			};
 			side="West";
 			flags=6;
@@ -475,16 +11557,15 @@ class Mission
 				init="[""v_helo_m"",this] call f_fnc_assignGear";
 				name="VehNATO_TH7";
 			};
-			id=8;
+			id=2559;
 			type="B_Heli_Transport_01_F";
-			atlOffset=-1.2397766e-005;
 		};
-		class Item9
+		class Item142
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={563.22864,7.1392474,1222.3273};
+				position[]={563.229,7.1392598,1222.3274};
 			};
 			side="West";
 			flags=6;
@@ -494,16 +11575,15 @@ class Mission
 				init="[""v_helo_m"",this] call f_fnc_assignGear";
 				name="VehNATO_TH8";
 			};
-			id=9;
+			id=2560;
 			type="B_Heli_Transport_01_F";
-			atlOffset=-1.2397766e-005;
 		};
-		class Item10
+		class Item143
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={470.42007,7.4527192,1304.1699};
+				position[]={470.42001,7.4527192,1304.17};
 			};
 			side="West";
 			flags=6;
@@ -513,16 +11593,16 @@ class Mission
 				init="[""v_ifv"",this] call f_fnc_assignGear;";
 				name="VehNATO_AV";
 			};
-			id=10;
+			id=2561;
 			type="B_APC_Tracked_01_rcws_F";
 			atlOffset=-0.17999983;
 		};
-		class Item11
+		class Item144
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={517.84583,7.4527192,1301.2305};
+				position[]={517.84601,7.4527192,1301.23};
 			};
 			side="West";
 			flags=6;
@@ -532,16 +11612,16 @@ class Mission
 				init="[""v_ifv"",this] call f_fnc_assignGear;";
 				name="VehNATO_BV";
 			};
-			id=11;
+			id=2562;
 			type="B_APC_Tracked_01_rcws_F";
 			atlOffset=-0.17999983;
 		};
-		class Item12
+		class Item145
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={560.05579,7.4527192,1302.459};
+				position[]={560.05603,7.4527192,1302.459};
 			};
 			side="West";
 			flags=6;
@@ -551,16 +11631,16 @@ class Mission
 				init="[""v_ifv"",this] call f_fnc_assignGear;";
 				name="VehNATO_CV";
 			};
-			id=12;
+			id=2563;
 			type="B_APC_Tracked_01_rcws_F";
 			atlOffset=-0.17999983;
 		};
-		class Item13
+		class Item146
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={431.17886,7.4527192,1304.5967};
+				position[]={431.17899,7.4527192,1304.597};
 			};
 			side="West";
 			flags=6;
@@ -570,16 +11650,16 @@ class Mission
 				init="[""v_ifv"",this] call f_fnc_assignGear;";
 				name="VehNATO_COV";
 			};
-			id=13;
+			id=2564;
 			type="B_APC_Tracked_01_rcws_F";
 			atlOffset=-0.17999983;
 		};
-		class Item14
+		class Item147
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={431.90445,6.9319248,1193.7062};
+				position[]={431.90399,6.9319367,1193.7064};
 			};
 			side="West";
 			flags=6;
@@ -591,16 +11671,16 @@ class Mission
 				reportRemoteTargets=1;
 				receiveRemoteTargets=1;
 			};
-			id=14;
+			id=2565;
 			type="B_Heli_Attack_01_dynamicLoadout_F";
-			atlOffset=0.009988308;
+			atlOffset=0.010000229;
 		};
-		class Item15
+		class Item148
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1452.1128,8.5861206,618.69836};
+				position[]={1424.882,8.610199,1219.2489};
 			};
 			side="Independent";
 			flags=6;
@@ -610,16 +11690,15 @@ class Mission
 				init="[""v_helo_h"",this] call f_fnc_assignGear";
 				name="VehAAF_TH2";
 			};
-			id=15;
+			id=2566;
 			type="I_Heli_Transport_02_F";
-			atlOffset=-0.024078369;
 		};
-		class Item16
+		class Item149
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1494.3599,8.5861206,619.53918};
+				position[]={1467.129,8.610199,1220.0898};
 			};
 			side="Independent";
 			flags=6;
@@ -629,16 +11708,15 @@ class Mission
 				init="[""v_helo_h"",this] call f_fnc_assignGear";
 				name="VehAAF_TH3";
 			};
-			id=16;
+			id=2567;
 			type="I_Heli_Transport_02_F";
-			atlOffset=-0.024078369;
 		};
-		class Item17
+		class Item150
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1535.6772,8.5861206,620.19543};
+				position[]={1508.446,8.610199,1220.7458};
 			};
 			side="Independent";
 			flags=6;
@@ -649,16 +11727,15 @@ class Mission
 				init="[""v_helo_h"",this] call f_fnc_assignGear";
 				name="VehAAF_TH4";
 			};
-			id=17;
+			id=2568;
 			type="I_Heli_Transport_02_F";
-			atlOffset=-0.024078369;
 		};
-		class Item18
+		class Item151
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={2380.8411,7.5924172,1224.6206};
+				position[]={2380.8411,7.5924172,1224.6202};
 			};
 			side="East";
 			flags=6;
@@ -669,15 +11746,15 @@ class Mission
 				name="VehCSAT_TH2";
 				textures="Opfor";
 			};
-			id=18;
+			id=2569;
 			type="O_Heli_Transport_04_covered_F";
 		};
-		class Item19
+		class Item152
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={2429.5403,7.1696463,1253.569};
+				position[]={2429.54,7.1696463,1253.5693};
 			};
 			side="East";
 			flags=6;
@@ -689,15 +11766,15 @@ class Mission
 				receiveRemoteTargets=1;
 				pylons=";;";
 			};
-			id=19;
+			id=2570;
 			type="O_Heli_Light_02_dynamicLoadout_F";
 		};
-		class Item20
+		class Item153
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={2426.9114,7.1696463,1223.8492};
+				position[]={2426.9109,7.1696463,1223.8492};
 			};
 			side="East";
 			flags=6;
@@ -709,15 +11786,15 @@ class Mission
 				receiveRemoteTargets=1;
 				pylons=";;";
 			};
-			id=20;
+			id=2571;
 			type="O_Heli_Light_02_dynamicLoadout_F";
 		};
-		class Item21
+		class Item154
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={2480.3333,7.1696463,1253.2291};
+				position[]={2480.333,7.1696463,1253.2292};
 			};
 			side="East";
 			flags=6;
@@ -729,15 +11806,15 @@ class Mission
 				receiveRemoteTargets=1;
 				pylons=";;";
 			};
-			id=21;
+			id=2572;
 			type="O_Heli_Light_02_dynamicLoadout_F";
 		};
-		class Item22
+		class Item155
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={2477.6995,7.1696463,1223.5045};
+				position[]={2477.699,7.1696463,1223.5043};
 			};
 			side="East";
 			flags=6;
@@ -749,15 +11826,15 @@ class Mission
 				receiveRemoteTargets=1;
 				pylons=";;";
 			};
-			id=22;
+			id=2573;
 			type="O_Heli_Light_02_dynamicLoadout_F";
 		};
-		class Item23
+		class Item156
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={2534.553,7.1696463,1253.6246};
+				position[]={2534.553,7.1696463,1253.6243};
 			};
 			side="East";
 			flags=6;
@@ -769,15 +11846,15 @@ class Mission
 				receiveRemoteTargets=1;
 				pylons=";;";
 			};
-			id=23;
+			id=2574;
 			type="O_Heli_Light_02_dynamicLoadout_F";
 		};
-		class Item24
+		class Item157
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={2531.9211,7.1696463,1223.9039};
+				position[]={2531.9209,7.1696463,1223.9043};
 			};
 			side="East";
 			flags=6;
@@ -789,15 +11866,15 @@ class Mission
 				receiveRemoteTargets=1;
 				pylons=";;";
 			};
-			id=24;
+			id=2575;
 			type="O_Heli_Light_02_dynamicLoadout_F";
 		};
-		class Item25
+		class Item158
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={2381.1594,7.5568428,1301.3188};
+				position[]={2381.1589,7.5568428,1301.319};
 			};
 			side="East";
 			flags=4;
@@ -808,15 +11885,15 @@ class Mission
 				name="VehCSAT_COV";
 				textures="Hex";
 			};
-			id=25;
+			id=2576;
 			type="O_APC_Wheeled_02_rcws_v2_F";
 		};
-		class Item26
+		class Item159
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={2423.8577,7.5568428,1301.0942};
+				position[]={2423.8579,7.5568428,1301.094};
 			};
 			side="East";
 			flags=4;
@@ -827,15 +11904,15 @@ class Mission
 				name="VehCSAT_AV";
 				textures="Hex";
 			};
-			id=26;
+			id=2577;
 			type="O_APC_Wheeled_02_rcws_v2_F";
 		};
-		class Item27
+		class Item160
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={2475.9973,7.5568428,1300.3062};
+				position[]={2475.9971,7.5568428,1300.306};
 			};
 			side="East";
 			flags=4;
@@ -846,15 +11923,15 @@ class Mission
 				name="VehCSAT_BV";
 				textures="Hex";
 			};
-			id=27;
+			id=2578;
 			type="O_APC_Wheeled_02_rcws_v2_F";
 		};
-		class Item28
+		class Item161
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={2529.1165,7.5568428,1300.1157};
+				position[]={2529.116,7.5568428,1300.116};
 			};
 			side="East";
 			flags=4;
@@ -865,15 +11942,15 @@ class Mission
 				name="VehCSAT_CV";
 				textures="Hex";
 			};
-			id=28;
+			id=2579;
 			type="O_APC_Wheeled_02_rcws_v2_F";
 		};
-		class Item29
+		class Item162
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={2382.634,8.0559025,1193.7076};
+				position[]={2382.634,8.0559025,1193.7081};
 			};
 			side="East";
 			flags=6;
@@ -886,15 +11963,15 @@ class Mission
 				reportRemoteTargets=1;
 				receiveRemoteTargets=1;
 			};
-			id=29;
+			id=2580;
 			type="O_Heli_Attack_02_dynamicLoadout_F";
 		};
-		class Item30
+		class Item163
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={516.48157,7.5372982,1279.7227};
+				position[]={516.48199,7.5374756,1279.723};
 			};
 			side="West";
 			flags=6;
@@ -904,16 +11981,16 @@ class Mission
 				init="[""v_tank"",this] call f_fnc_assignGear;";
 				name="VehNATO_TNK1";
 			};
-			id=30;
+			id=2581;
 			type="B_MBT_01_TUSK_F";
-			atlOffset=-0.18917751;
+			atlOffset=-0.18900013;
 		};
-		class Item31
+		class Item164
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1408.4087,7.6142888,675.24231};
+				position[]={1381.178,7.6142888,1275.793};
 			};
 			side="Independent";
 			flags=6;
@@ -923,15 +12000,15 @@ class Mission
 				init="[""v_ifv"",this] call f_fnc_assignGear;";
 				name="VehAAF_COV";
 			};
-			id=31;
+			id=2582;
 			type="I_APC_Wheeled_03_cannon_F";
 		};
-		class Item32
+		class Item165
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1453.1089,7.6142888,674.10168};
+				position[]={1425.8781,7.6142888,1274.653};
 			};
 			side="Independent";
 			flags=6;
@@ -941,15 +12018,15 @@ class Mission
 				init="[""v_ifv"",this] call f_fnc_assignGear;";
 				name="VehAAF_AV";
 			};
-			id=32;
+			id=2583;
 			type="I_APC_Wheeled_03_cannon_F";
 		};
-		class Item33
+		class Item166
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1493.9253,7.6142888,674.16711};
+				position[]={1466.694,7.6142888,1274.718};
 			};
 			side="Independent";
 			flags=6;
@@ -959,15 +12036,15 @@ class Mission
 				init="[""v_ifv"",this] call f_fnc_assignGear;";
 				name="VehAAF_BV";
 			};
-			id=33;
+			id=2584;
 			type="I_APC_Wheeled_03_cannon_F";
 		};
-		class Item34
+		class Item167
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1535.4771,7.6142888,674.45129};
+				position[]={1508.246,7.6142888,1275.002};
 			};
 			side="Independent";
 			flags=6;
@@ -977,15 +12054,15 @@ class Mission
 				init="[""v_ifv"",this] call f_fnc_assignGear;";
 				name="VehAAF_CV";
 			};
-			id=34;
+			id=2585;
 			type="I_APC_Wheeled_03_cannon_F";
 		};
-		class Item35
+		class Item168
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={2477.0383,7.1897745,1274.8247};
+				position[]={2477.0381,7.1894407,1274.825};
 			};
 			side="East";
 			flags=6;
@@ -996,16 +12073,16 @@ class Mission
 				name="VehCSAT_TNK1";
 				textures="Hex";
 			};
-			id=35;
+			id=2586;
 			type="O_MBT_02_cannon_F";
-			atlOffset=-0.18066597;
+			atlOffset=-0.18099976;
 		};
-		class Item36
+		class Item169
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1493.9966,7.5486078,650.39954};
+				position[]={1466.766,7.7286081,1250.95};
 			};
 			side="Independent";
 			flags=6;
@@ -1015,16 +12092,15 @@ class Mission
 				init="[""v_tank"",this] call f_fnc_assignGear;";
 				name="VehAAF_TNK1";
 			};
-			id=36;
+			id=2587;
 			type="I_MBT_03_cannon_F";
-			atlOffset=-0.18000031;
 		};
-		class Item37
+		class Item170
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1408.8267,6.5310755,586.50305};
+				position[]={1381.5959,6.5310755,1187.054};
 			};
 			side="Independent";
 			flags=6;
@@ -1035,15 +12111,15 @@ class Mission
 				name="VehAAF_AH1";
 				receiveRemoteTargets=1;
 			};
-			id=37;
+			id=2588;
 			type="I_Heli_light_03_dynamicLoadout_F";
 		};
-		class Item38
+		class Item171
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1451.1421,7.3817043,777.82239};
+				position[]={1423.9111,7.3817577,1378.3733};
 			};
 			side="Empty";
 			flags=4;
@@ -1053,16 +12129,15 @@ class Mission
 				init="[""v_tr"",this] call f_fnc_assignGear";
 				name="VehAAF_TR1";
 			};
-			id=38;
+			id=2589;
 			type="I_Truck_02_transport_F";
-			atlOffset=-5.3405762e-005;
 		};
-		class Item39
+		class Item172
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1496.5581,7.3817043,777.77649};
+				position[]={1469.3271,7.3817577,1378.3274};
 			};
 			side="Empty";
 			flags=4;
@@ -1072,16 +12147,15 @@ class Mission
 				init="[""v_tr"",this] call f_fnc_assignGear";
 				name="VehAAF_TR2";
 			};
-			id=39;
+			id=2590;
 			type="I_Truck_02_transport_F";
-			atlOffset=-5.3405762e-005;
 		};
-		class Item40
+		class Item173
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1538.6558,7.3817043,777.95032};
+				position[]={1511.4248,7.3817577,1378.5012};
 			};
 			side="Empty";
 			flags=4;
@@ -1091,16 +12165,15 @@ class Mission
 				init="[""v_tr"",this] call f_fnc_assignGear";
 				name="VehAAF_TR3";
 			};
-			id=40;
+			id=2591;
 			type="I_Truck_02_transport_F";
-			atlOffset=-5.3405762e-005;
 		};
-		class Item41
+		class Item174
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1400.7506,6.8319178,763.49799};
+				position[]={1373.5197,6.8319178,1364.0488};
 			};
 			side="Empty";
 			flags=4;
@@ -1111,10 +12184,10 @@ class Mission
 				name="VehAAF_CAR1";
 				reportRemoteTargets=1;
 			};
-			id=41;
+			id=2592;
 			type="I_MRAP_03_F";
 		};
-		class Item42
+		class Item175
 		{
 			dataType="Object";
 			class PositionInfo
@@ -1129,10 +12202,10 @@ class Mission
 				init="[""v_car"",this] call f_fnc_assignGear";
 				name="VehNato_CAR1";
 			};
-			id=42;
+			id=2593;
 			type="B_MRAP_01_F";
 		};
-		class Item43
+		class Item176
 		{
 			dataType="Object";
 			class PositionInfo
@@ -1147,10 +12220,10 @@ class Mission
 				init="[""v_tr"",this] call f_fnc_assignGear";
 				name="VehNato_TR1";
 			};
-			id=43;
+			id=2594;
 			type="B_Truck_01_transport_F";
 		};
-		class Item44
+		class Item177
 		{
 			dataType="Object";
 			class PositionInfo
@@ -1165,10 +12238,10 @@ class Mission
 				init="[""v_tr"",this] call f_fnc_assignGear";
 				name="VehNato_TR2";
 			};
-			id=44;
+			id=2595;
 			type="B_Truck_01_transport_F";
 		};
-		class Item45
+		class Item178
 		{
 			dataType="Object";
 			class PositionInfo
@@ -1183,10 +12256,10 @@ class Mission
 				init="[""v_tr"",this] call f_fnc_assignGear";
 				name="VehNato_TR3";
 			};
-			id=45;
+			id=2596;
 			type="B_Truck_01_transport_F";
 		};
-		class Item46
+		class Item179
 		{
 			dataType="Object";
 			class PositionInfo
@@ -1202,10 +12275,10 @@ class Mission
 				name="VehCSAT_CAR1";
 				textures="Hex";
 			};
-			id=46;
+			id=2597;
 			type="O_MRAP_02_F";
 		};
-		class Item47
+		class Item180
 		{
 			dataType="Object";
 			class PositionInfo
@@ -1220,11 +12293,11 @@ class Mission
 				init="[""v_tr"",this] call f_fnc_assignGear";
 				name="VehCSAT_TR1";
 			};
-			id=47;
+			id=2598;
 			type="O_Truck_02_transport_F";
 			atlOffset=-5.3405762e-005;
 		};
-		class Item48
+		class Item181
 		{
 			dataType="Object";
 			class PositionInfo
@@ -1239,11 +12312,11 @@ class Mission
 				init="[""v_tr"",this] call f_fnc_assignGear";
 				name="VehCSAT_TR2";
 			};
-			id=48;
+			id=2599;
 			type="O_Truck_02_transport_F";
 			atlOffset=-5.3405762e-005;
 		};
-		class Item49
+		class Item182
 		{
 			dataType="Object";
 			class PositionInfo
@@ -1258,16 +12331,16 @@ class Mission
 				init="[""v_tr"",this] call f_fnc_assignGear";
 				name="VehCSAT_TR3";
 			};
-			id=49;
+			id=2600;
 			type="O_Truck_02_transport_F";
 			atlOffset=-5.3405762e-005;
 		};
-		class Item50
+		class Item183
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={616.46912,6.6115026,726.53906};
+				position[]={609.92908,6.6115026,918.35986};
 			};
 			side="Empty";
 			flags=4;
@@ -1278,15 +12351,15 @@ class Mission
 				name="VehFIA_CAR4";
 				textures="Guerilla_07";
 			};
-			id=50;
+			id=2601;
 			type="B_G_Offroad_01_F";
 		};
-		class Item51
+		class Item184
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={440.55112,6.6115026,757.85254};
+				position[]={434.01099,6.6115026,949.67334};
 			};
 			side="Empty";
 			flags=4;
@@ -1297,15 +12370,15 @@ class Mission
 				name="VehFIA_CAR1";
 				textures="Guerilla_07";
 			};
-			id=51;
+			id=2602;
 			type="B_G_Offroad_01_F";
 		};
-		class Item52
+		class Item185
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={440.63022,6.7971687,735.33008};
+				position[]={434.09009,6.7971687,927.15088};
 			};
 			side="Empty";
 			flags=4;
@@ -1316,16 +12389,16 @@ class Mission
 				name="VehFIA_CAR2";
 				textures="Guerilla_07";
 			};
-			id=52;
+			id=2603;
 			type="B_G_Offroad_01_F";
 			atlOffset=0.18566608;
 		};
-		class Item53
+		class Item186
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={615.70349,6.6115026,749.10645};
+				position[]={609.16345,6.6115026,940.92725};
 			};
 			side="Empty";
 			flags=4;
@@ -1336,15 +12409,15 @@ class Mission
 				name="VehFIA_CAR3";
 				textures="Guerilla_07";
 			};
-			id=53;
+			id=2604;
 			type="B_G_Offroad_01_F";
 		};
-		class Item54
+		class Item187
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={481.93588,6.8716264,771.92865};
+				position[]={475.39575,6.8716264,963.74945};
 			};
 			side="Empty";
 			flags=4;
@@ -1355,16 +12428,16 @@ class Mission
 				name="VehFIA_TR1";
 				textures="Guerilla_04";
 			};
-			id=54;
+			id=2605;
 			type="B_G_Van_01_transport_F";
 			atlOffset=0.00011968613;
 		};
-		class Item55
+		class Item188
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={489.83334,6.8716264,767.43549};
+				position[]={483.29321,6.8716264,959.25629};
 			};
 			side="Empty";
 			flags=4;
@@ -1375,16 +12448,16 @@ class Mission
 				name="VehFIA_TR2";
 				textures="Guerilla_04";
 			};
-			id=55;
+			id=2606;
 			type="B_G_Van_01_transport_F";
 			atlOffset=0.00011968613;
 		};
-		class Item56
+		class Item189
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={525.84607,6.8716264,772.71674};
+				position[]={519.30615,6.8716264,964.53754};
 			};
 			side="Empty";
 			flags=4;
@@ -1395,16 +12468,16 @@ class Mission
 				name="VehFIA_TR3";
 				textures="Guerilla_04";
 			};
-			id=56;
+			id=2607;
 			type="B_G_Van_01_transport_F";
 			atlOffset=0.00011968613;
 		};
-		class Item57
+		class Item190
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1400.9404,6.8319178,734.03149};
+				position[]={1373.7095,6.8319178,1334.5823};
 			};
 			side="Empty";
 			flags=4;
@@ -1415,10 +12488,10 @@ class Mission
 				name="VehAAF_CAR2";
 				reportRemoteTargets=1;
 			};
-			id=57;
+			id=2608;
 			type="I_MRAP_03_F";
 		};
-		class Item58
+		class Item191
 		{
 			dataType="Object";
 			class PositionInfo
@@ -1434,10 +12507,10 @@ class Mission
 				name="VehCSAT_CAR2";
 				textures="Hex";
 			};
-			id=58;
+			id=2609;
 			type="O_MRAP_02_F";
 		};
-		class Item59
+		class Item192
 		{
 			dataType="Object";
 			class PositionInfo
@@ -1452,15 +12525,15 @@ class Mission
 				init="[""v_car"",this] call f_fnc_assignGear";
 				name="VehNato_CAR2";
 			};
-			id=59;
+			id=2610;
 			type="B_MRAP_01_F";
 		};
-		class Item60
+		class Item193
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1451.3696,5.8924227,765.56165};
+				position[]={1424.1387,5.8924227,1366.1125};
 			};
 			side="Empty";
 			flags=4;
@@ -1470,7 +12543,7 @@ class Mission
 				init="[""crate_med"",this,""ind_f""] call f_fnc_assignGear";
 				name="CrateAAF_A";
 			};
-			id=60;
+			id=2611;
 			type="I_supplyCrate_F";
 			class CustomAttributes
 			{
@@ -1496,12 +12569,12 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item61
+		class Item194
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1494.562,5.8924227,766.11731};
+				position[]={1467.3311,5.8924227,1366.6682};
 			};
 			side="Empty";
 			flags=4;
@@ -1511,7 +12584,7 @@ class Mission
 				init="[""crate_med"",this,""ind_f""] call f_fnc_assignGear";
 				name="CrateAAF_B";
 			};
-			id=61;
+			id=2612;
 			type="I_supplyCrate_F";
 			class CustomAttributes
 			{
@@ -1537,12 +12610,12 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item62
+		class Item195
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1539.1606,5.8924227,766.32043};
+				position[]={1511.9297,5.8924227,1366.8713};
 			};
 			side="Empty";
 			flags=4;
@@ -1552,7 +12625,7 @@ class Mission
 				init="[""crate_med"",this,""ind_f""] call f_fnc_assignGear";
 				name="CrateAAF_C";
 			};
-			id=62;
+			id=2613;
 			type="I_supplyCrate_F";
 			class CustomAttributes
 			{
@@ -1578,7 +12651,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item63
+		class Item196
 		{
 			dataType="Object";
 			class PositionInfo
@@ -1593,7 +12666,7 @@ class Mission
 				init="[""crate_med"",this,""blu_f""] call f_fnc_assignGear";
 				name="CrateNATO_A";
 			};
-			id=63;
+			id=2614;
 			type="B_supplyCrate_F";
 			class CustomAttributes
 			{
@@ -1619,7 +12692,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item64
+		class Item197
 		{
 			dataType="Object";
 			class PositionInfo
@@ -1634,7 +12707,7 @@ class Mission
 				init="[""crate_med"",this,""blu_f""] call f_fnc_assignGear";
 				name="CrateNATO_B";
 			};
-			id=64;
+			id=2615;
 			type="B_supplyCrate_F";
 			class CustomAttributes
 			{
@@ -1660,7 +12733,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item65
+		class Item198
 		{
 			dataType="Object";
 			class PositionInfo
@@ -1675,7 +12748,7 @@ class Mission
 				init="[""crate_med"",this,""blu_f""] call f_fnc_assignGear";
 				name="CrateNATO_C";
 			};
-			id=65;
+			id=2616;
 			type="B_supplyCrate_F";
 			class CustomAttributes
 			{
@@ -1701,7 +12774,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item66
+		class Item199
 		{
 			dataType="Object";
 			class PositionInfo
@@ -1716,7 +12789,7 @@ class Mission
 				init="[""crate_med"",this,""opf_f""] call f_fnc_assignGear";
 				name="CrateCSAT_A";
 			};
-			id=66;
+			id=2617;
 			type="O_supplyCrate_F";
 			class CustomAttributes
 			{
@@ -1742,7 +12815,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item67
+		class Item200
 		{
 			dataType="Object";
 			class PositionInfo
@@ -1757,7 +12830,7 @@ class Mission
 				init="[""crate_med"",this,""opf_f""] call f_fnc_assignGear";
 				name="CrateCSAT_B";
 			};
-			id=67;
+			id=2618;
 			type="O_supplyCrate_F";
 			class CustomAttributes
 			{
@@ -1783,7 +12856,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item68
+		class Item201
 		{
 			dataType="Object";
 			class PositionInfo
@@ -1798,7 +12871,7 @@ class Mission
 				init="[""crate_med"",this,""opf_f""] call f_fnc_assignGear";
 				name="CrateCSAT_C";
 			};
-			id=68;
+			id=2619;
 			type="O_supplyCrate_F";
 			class CustomAttributes
 			{
@@ -1824,12 +12897,12 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item69
+		class Item202
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={483.80991,5.8924227,764.7207};
+				position[]={477.26978,5.8924227,956.5415};
 			};
 			side="Empty";
 			flags=4;
@@ -1839,7 +12912,7 @@ class Mission
 				init="[""crate_med"",this,""blu_g_f""] call f_fnc_assignGear";
 				name="CrateFIA_A";
 			};
-			id=69;
+			id=2620;
 			type="IG_supplyCrate_F";
 			class CustomAttributes
 			{
@@ -1865,12 +12938,12 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item70
+		class Item203
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={525.81873,5.8924227,765.85156};
+				position[]={519.27881,5.8924227,957.67236};
 			};
 			side="Empty";
 			flags=4;
@@ -1880,7 +12953,7 @@ class Mission
 				init="[""crate_med"",this,""blu_g_f""] call f_fnc_assignGear";
 				name="CrateFIA_B";
 			};
-			id=70;
+			id=2621;
 			type="IG_supplyCrate_F";
 			class CustomAttributes
 			{
@@ -1906,12 +12979,12 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item71
+		class Item204
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={565.77478,5.8924227,764.64355};
+				position[]={559.23474,5.8924227,956.46436};
 			};
 			side="Empty";
 			flags=4;
@@ -1921,7 +12994,7 @@ class Mission
 				init="[""crate_med"",this,""blu_g_f""] call f_fnc_assignGear";
 				name="CrateFIA_C";
 			};
-			id=71;
+			id=2622;
 			type="IG_supplyCrate_F";
 			class CustomAttributes
 			{
@@ -1947,12 +13020,12 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item72
+		class Item205
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={604.48376,5.6047058,625.62299};
+				position[]={597.94403,5.6047058,817.44397};
 			};
 			side="West";
 			flags=6;
@@ -1963,15 +13036,15 @@ class Mission
 				name="VehFIA_TH1";
 				textures="Elliptical";
 			};
-			id=72;
+			id=2623;
 			type="C_Heli_Light_01_civil_F";
 		};
-		class Item73
+		class Item206
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={430.91617,7.4626956,1278.9102};
+				position[]={430.91599,7.4623775,1278.91};
 			};
 			side="West";
 			flags=6;
@@ -1981,16 +13054,16 @@ class Mission
 				init="[""v_ifv"",this] call f_fnc_assignGear;";
 				name="VehNATO_IFV1";
 			};
-			id=73;
+			id=2624;
 			type="B_APC_Wheeled_01_cannon_F";
-			atlOffset=-0.076682091;
+			atlOffset=-0.077000141;
 		};
-		class Item74
+		class Item207
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={470.5939,7.4626956,1279.0977};
+				position[]={470.59399,7.4623775,1279.098};
 			};
 			side="West";
 			flags=6;
@@ -2000,11 +13073,11 @@ class Mission
 				init="[""v_ifv"",this] call f_fnc_assignGear;";
 				name="VehNATO_IFV2";
 			};
-			id=74;
+			id=2625;
 			type="B_APC_Wheeled_01_cannon_F";
-			atlOffset=-0.076682091;
+			atlOffset=-0.077000141;
 		};
-		class Item75
+		class Item208
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2019,10 +13092,10 @@ class Mission
 				init="[""v_car"",this] call f_fnc_assignGear";
 				name="VehNato_CAR3";
 			};
-			id=75;
+			id=2626;
 			type="B_MRAP_01_F";
 		};
-		class Item76
+		class Item209
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2037,15 +13110,15 @@ class Mission
 				init="[""v_car"",this] call f_fnc_assignGear";
 				name="VehNato_CAR4";
 			};
-			id=76;
+			id=2627;
 			type="B_MRAP_01_F";
 		};
-		class Item77
+		class Item210
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={2381.4866,7.392787,1275.9663};
+				position[]={2381.4871,7.3928018,1275.9659};
 			};
 			side="East";
 			flags=6;
@@ -2056,16 +13129,16 @@ class Mission
 				name="VehCSAT_IFV1";
 				textures="Hex";
 			};
-			id=77;
+			id=2628;
 			type="O_APC_Tracked_02_cannon_F";
-			atlOffset=-0.18001461;
+			atlOffset=-0.17999983;
 		};
-		class Item78
+		class Item211
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={2426.5959,7.392787,1276.311};
+				position[]={2426.5959,7.3928018,1276.311};
 			};
 			side="East";
 			flags=6;
@@ -2076,11 +13149,11 @@ class Mission
 				name="VehCSAT_IFV2";
 				textures="Hex";
 			};
-			id=78;
+			id=2629;
 			type="O_APC_Tracked_02_cannon_F";
-			atlOffset=-0.18001461;
+			atlOffset=-0.17999983;
 		};
-		class Item79
+		class Item212
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2096,10 +13169,10 @@ class Mission
 				name="VehCSAT_CAR3";
 				textures="Hex";
 			};
-			id=79;
+			id=2630;
 			type="O_MRAP_02_F";
 		};
-		class Item80
+		class Item213
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2115,15 +13188,15 @@ class Mission
 				name="VehCSAT_CAR4";
 				textures="Hex";
 			};
-			id=80;
+			id=2631;
 			type="O_MRAP_02_F";
 		};
-		class Item81
+		class Item214
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1409.1245,7.6859746,652.05188};
+				position[]={1381.894,7.6857953,1252.603};
 			};
 			side="Independent";
 			flags=6;
@@ -2133,16 +13206,16 @@ class Mission
 				init="[""v_ifv"",this] call f_fnc_assignGear;";
 				name="VehAAF_IFV1";
 			};
-			id=81;
+			id=2632;
 			type="I_APC_tracked_03_cannon_F";
-			atlOffset=0.17517948;
+			atlOffset=0.17500019;
 		};
-		class Item82
+		class Item215
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1452.3257,7.4890223,649.7052};
+				position[]={1425.095,7.5107951,1250.256};
 			};
 			side="Independent";
 			flags=6;
@@ -2152,16 +13225,15 @@ class Mission
 				init="[""v_ifv"",this] call f_fnc_assignGear;";
 				name="VehAAF_IFV2";
 			};
-			id=82;
+			id=2633;
 			type="I_APC_tracked_03_cannon_F";
-			atlOffset=-0.021772861;
 		};
-		class Item83
+		class Item216
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1611.853,6.8319178,753.23547};
+				position[]={1584.6221,6.8319178,1353.7864};
 			};
 			side="Empty";
 			flags=4;
@@ -2172,15 +13244,15 @@ class Mission
 				name="VehAAF_CAR3";
 				reportRemoteTargets=1;
 			};
-			id=83;
+			id=2634;
 			type="I_MRAP_03_F";
 		};
-		class Item84
+		class Item217
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1613.3022,6.8319178,725.57043};
+				position[]={1586.0713,6.8319178,1326.1213};
 			};
 			side="Empty";
 			flags=4;
@@ -2191,15 +13263,15 @@ class Mission
 				name="VehAAF_CAR4";
 				reportRemoteTargets=1;
 			};
-			id=84;
+			id=2635;
 			type="I_MRAP_03_F";
 		};
-		class Item85
+		class Item218
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={448.18198,7.1644082,686.50494};
+				position[]={441.642,7.1644082,878.32532};
 			};
 			side="West";
 			flags=6;
@@ -2210,15 +13282,15 @@ class Mission
 				name="VehFIA_IFV1";
 				textures="Guerilla_07";
 			};
-			id=85;
+			id=2636;
 			type="B_G_Offroad_01_armed_F";
 		};
-		class Item86
+		class Item219
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={482.90561,7.1644082,686.42194};
+				position[]={476.36499,7.1644082,878.24231};
 			};
 			side="West";
 			flags=6;
@@ -2229,15 +13301,15 @@ class Mission
 				name="VehFIA_IFV2";
 				textures="Guerilla_07";
 			};
-			id=86;
+			id=2637;
 			type="B_G_Offroad_01_armed_F";
 		};
-		class Item87
+		class Item220
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={535.95642,6.8716264,767.56049};
+				position[]={529.4165,6.8716264,959.38129};
 			};
 			side="Empty";
 			flags=4;
@@ -2248,16 +13320,16 @@ class Mission
 				name="VehFIA_TR4";
 				textures="Guerilla_04";
 			};
-			id=87;
+			id=2638;
 			type="B_G_Van_01_transport_F";
 			atlOffset=0.00011968613;
 		};
-		class Item88
+		class Item221
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={566.30212,6.8716264,772.56244};
+				position[]={559.76208,6.8716264,964.38324};
 			};
 			side="Empty";
 			flags=4;
@@ -2268,16 +13340,16 @@ class Mission
 				name="VehFIA_TR5";
 				textures="Guerilla_04";
 			};
-			id=88;
+			id=2639;
 			type="B_G_Van_01_transport_F";
 			atlOffset=0.00011968613;
 		};
-		class Item89
+		class Item222
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={575.16443,6.8716264,767.05365};
+				position[]={568.62439,6.8716264,958.87445};
 			};
 			side="Empty";
 			flags=4;
@@ -2288,19 +13360,19 @@ class Mission
 				name="VehFIA_TR6";
 				textures="Guerilla_04";
 			};
-			id=89;
+			id=2640;
 			type="B_G_Van_01_transport_F";
 			atlOffset=0.00011968613;
 		};
-		class Item90
+		class Item223
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={2281.6389,5.3882694,729.50195};
+				position[]={2332.5256,5.3882694,527.68066};
 			};
 			init="[this, true, allUnits] call f_fnc_zeusInit;";
-			id=106;
+			id=2641;
 			type="ModuleCurator_F";
 			atlOffset=0.38826942;
 			class CustomAttributes
@@ -2403,15 +13475,15 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item91
+		class Item224
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={2282.2229,5.3580265,718.42773};
+				position[]={2333.1096,5.3580265,516.60645};
 			};
 			init="[this, true, allUnits] call f_fnc_zeusInit;";
-			id=107;
+			id=2642;
 			type="ModuleCurator_F";
 			atlOffset=0.3580265;
 			class CustomAttributes
@@ -2514,15 +13586,15 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item92
+		class Item225
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={2282.3342,5.6426582,707.78223};
+				position[]={2333.2209,5.6426582,505.96094};
 			};
 			init="[this, true, allUnits] call f_fnc_zeusInit;";
-			id=108;
+			id=2643;
 			type="ModuleCurator_F";
 			atlOffset=0.64265823;
 			class CustomAttributes
@@ -2625,15 +13697,15 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item93
+		class Item226
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={2284.1614,6.0756798,697.16992};
+				position[]={2335.0481,6.0756798,495.34863};
 			};
 			init="[this, true, allUnits] call f_fnc_zeusInit;";
-			id=109;
+			id=2644;
 			type="ModuleCurator_F";
 			atlOffset=1.0756798;
 			class CustomAttributes
@@ -2736,14 +13808,14 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item94
+		class Item227
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
 				position[]={411.01968,5,1370.0654};
 			};
-			id=110;
+			id=2645;
 			type="SupportRequester";
 			class CustomAttributes
 			{
@@ -2883,7 +13955,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item95
+		class Item228
 		{
 			dataType="Group";
 			side="West";
@@ -2902,7 +13974,7 @@ class Mission
 					class Attributes
 					{
 					};
-					id=115;
+					id=2647;
 					type="B_Soldier_F";
 				};
 			};
@@ -2921,8 +13993,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=115;
-						item1=114;
+						item0=2647;
+						item1=2648;
 						class CustomData
 						{
 							role=2;
@@ -2931,9 +14003,9 @@ class Mission
 					};
 				};
 			};
-			id=113;
+			id=2646;
 		};
-		class Item96
+		class Item229
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2946,10 +14018,10 @@ class Mission
 			{
 				skill=0.60000002;
 			};
-			id=114;
+			id=2648;
 			type="B_Mortar_01_F";
 		};
-		class Item97
+		class Item230
 		{
 			dataType="Group";
 			side="West";
@@ -2968,7 +14040,7 @@ class Mission
 					class Attributes
 					{
 					};
-					id=118;
+					id=2650;
 					type="B_Helipilot_F";
 				};
 				class Item1
@@ -2983,7 +14055,7 @@ class Mission
 					class Attributes
 					{
 					};
-					id=119;
+					id=2651;
 					type="B_Helipilot_F";
 				};
 			};
@@ -3002,8 +14074,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=118;
-						item1=117;
+						item0=2650;
+						item1=2652;
 						class CustomData
 						{
 							role=1;
@@ -3012,8 +14084,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=119;
-						item1=117;
+						item0=2651;
+						item1=2652;
 						class CustomData
 						{
 							role=2;
@@ -3022,10 +14094,10 @@ class Mission
 					};
 				};
 			};
-			id=116;
+			id=2649;
 			atlOffset=-0.37890196;
 		};
-		class Item98
+		class Item231
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3039,18 +14111,18 @@ class Mission
 				skill=0.60000002;
 				receiveRemoteTargets=1;
 			};
-			id=117;
+			id=2652;
 			type="B_Heli_Light_01_dynamicLoadout_F";
 			atlOffset=-0.37890196;
 		};
-		class Item99
+		class Item232
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={429.65366,5.4784107,754.7207};
+				position[]={423.11353,5.4784107,946.5415};
 			};
-			id=120;
+			id=2653;
 			type="SupportRequester";
 			atlOffset=0.47841072;
 			class CustomAttributes
@@ -3191,7 +14263,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item100
+		class Item233
 		{
 			dataType="Group";
 			side="West";
@@ -3203,14 +14275,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={427.57455,5.3587284,749.52301};
+						position[]={421.03442,5.3587284,941.34381};
 					};
 					side="West";
 					flags=2;
 					class Attributes
 					{
 					};
-					id=125;
+					id=2655;
 					type="B_Soldier_F";
 					atlOffset=0.35728931;
 				};
@@ -3230,8 +14302,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=125;
-						item1=124;
+						item0=2655;
+						item1=2656;
 						class CustomData
 						{
 							role=2;
@@ -3240,15 +14312,15 @@ class Mission
 					};
 				};
 			};
-			id=123;
+			id=2654;
 			atlOffset=0.35728931;
 		};
-		class Item101
+		class Item234
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={427.57455,6.0789151,749.47266};
+				position[]={421.03442,6.0789151,941.29346};
 			};
 			side="West";
 			flags=2;
@@ -3256,11 +14328,11 @@ class Mission
 			{
 				skill=0.60000002;
 			};
-			id=124;
+			id=2656;
 			type="B_Mortar_01_F";
 			atlOffset=0.35728931;
 		};
-		class Item102
+		class Item235
 		{
 			dataType="Group";
 			side="West";
@@ -3272,31 +14344,32 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={431.92221,5.3898754,748.29926};
+						position[]={425.38208,5.0109735,940.11981};
 					};
 					side="West";
-					flags=2;
+					flags=6;
 					class Attributes
 					{
 					};
-					id=128;
+					id=2658;
 					type="B_Helipilot_F";
-					atlOffset=0.38843632;
+					atlOffset=0.009534359;
 				};
 				class Item1
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={431.92221,5.3898754,748.29926};
+						position[]={425.38208,5.0109735,940.11981};
 					};
 					side="West";
+					flags=4;
 					class Attributes
 					{
 					};
-					id=129;
+					id=2659;
 					type="B_Helipilot_F";
-					atlOffset=0.38843632;
+					atlOffset=0.009534359;
 				};
 			};
 			class Attributes
@@ -3314,8 +14387,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=128;
-						item1=127;
+						item0=2658;
+						item1=2660;
 						class CustomData
 						{
 							role=1;
@@ -3324,8 +14397,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=129;
-						item1=127;
+						item0=2659;
+						item1=2660;
 						class CustomData
 						{
 							role=2;
@@ -3334,15 +14407,15 @@ class Mission
 					};
 				};
 			};
-			id=126;
+			id=2657;
 			atlOffset=0.009534359;
 		};
-		class Item103
+		class Item236
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={431.92221,6.7886786,748.25006};
+				position[]={425.38208,6.7886786,940.07086};
 			};
 			side="West";
 			flags=6;
@@ -3351,18 +14424,18 @@ class Mission
 				skill=0.60000002;
 				receiveRemoteTargets=1;
 			};
-			id=127;
+			id=2660;
 			type="B_Heli_Light_01_dynamicLoadout_F";
 			atlOffset=0.009534359;
 		};
-		class Item104
+		class Item237
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={430.49057,5.8319387,730.8916};
+				position[]={423.95044,5.8319387,922.7124};
 			};
-			id=130;
+			id=2661;
 			type="SupportRequester";
 			atlOffset=0.83193874;
 			class CustomAttributes
@@ -3503,7 +14576,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item105
+		class Item238
 		{
 			dataType="Group";
 			side="West";
@@ -3515,14 +14588,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={428.43491,5.7404861,725.74664};
+						position[]={421.89478,5.7404861,917.56744};
 					};
 					side="West";
 					flags=2;
 					class Attributes
 					{
 					};
-					id=135;
+					id=2663;
 					type="B_Soldier_F";
 					atlOffset=0.73904705;
 				};
@@ -3542,8 +14615,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=135;
-						item1=134;
+						item0=2663;
+						item1=2664;
 						class CustomData
 						{
 							role=2;
@@ -3552,15 +14625,15 @@ class Mission
 					};
 				};
 			};
-			id=133;
+			id=2662;
 			atlOffset=0.73904705;
 		};
-		class Item106
+		class Item239
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={428.43491,6.4606729,725.69629};
+				position[]={421.89478,6.4606729,917.51709};
 			};
 			side="West";
 			flags=2;
@@ -3568,11 +14641,11 @@ class Mission
 			{
 				skill=0.60000002;
 			};
-			id=134;
+			id=2664;
 			type="B_Mortar_01_F";
 			atlOffset=0.73904705;
 		};
-		class Item107
+		class Item240
 		{
 			dataType="Group";
 			side="West";
@@ -3584,31 +14657,32 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={432.80014,5.5899277,724.50336};
+						position[]={426.26001,5.2110257,916.32391};
 					};
 					side="West";
-					flags=2;
+					flags=6;
 					class Attributes
 					{
 					};
-					id=138;
+					id=2666;
 					type="B_Helipilot_F";
-					atlOffset=0.58848858;
+					atlOffset=0.20958662;
 				};
 				class Item1
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={432.80014,5.5899277,724.50336};
+						position[]={426.26001,5.2110257,916.32391};
 					};
 					side="West";
+					flags=4;
 					class Attributes
 					{
 					};
-					id=139;
+					id=2667;
 					type="B_Helipilot_F";
-					atlOffset=0.58848858;
+					atlOffset=0.20958662;
 				};
 			};
 			class Attributes
@@ -3626,8 +14700,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=138;
-						item1=137;
+						item0=2666;
+						item1=2668;
 						class CustomData
 						{
 							role=1;
@@ -3636,8 +14710,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=139;
-						item1=137;
+						item0=2667;
+						item1=2668;
 						class CustomData
 						{
 							role=2;
@@ -3646,15 +14720,15 @@ class Mission
 					};
 				};
 			};
-			id=136;
+			id=2665;
 			atlOffset=0.20958662;
 		};
-		class Item108
+		class Item241
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={432.80014,6.9887309,724.45416};
+				position[]={426.26001,6.9887309,916.27496};
 			};
 			side="West";
 			flags=6;
@@ -3663,18 +14737,18 @@ class Mission
 				skill=0.60000002;
 				receiveRemoteTargets=1;
 			};
-			id=137;
+			id=2668;
 			type="B_Heli_Light_01_dynamicLoadout_F";
 			atlOffset=0.20958662;
 		};
-		class Item109
+		class Item242
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
 				position[]={2352.8674,5,1375.1069};
 			};
-			id=140;
+			id=2669;
 			type="SupportRequester";
 			class CustomAttributes
 			{
@@ -3814,7 +14888,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item110
+		class Item243
 		{
 			dataType="Group";
 			side="East";
@@ -3833,7 +14907,7 @@ class Mission
 					class Attributes
 					{
 					};
-					id=145;
+					id=2671;
 					type="O_helipilot_F";
 				};
 				class Item1
@@ -3848,7 +14922,7 @@ class Mission
 					class Attributes
 					{
 					};
-					id=146;
+					id=2672;
 					type="O_helipilot_F";
 				};
 			};
@@ -3867,8 +14941,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=145;
-						item1=144;
+						item0=2671;
+						item1=2673;
 						class CustomData
 						{
 							role=1;
@@ -3877,8 +14951,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=146;
-						item1=144;
+						item0=2672;
+						item1=2673;
 						class CustomData
 						{
 							role=2;
@@ -3887,9 +14961,9 @@ class Mission
 					};
 				};
 			};
-			id=143;
+			id=2670;
 		};
-		class Item111
+		class Item244
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3904,10 +14978,10 @@ class Mission
 				receiveRemoteTargets=1;
 				pylons="PylonWeapon_2000Rnd_65x39_belt;PylonRack_12Rnd_missiles;";
 			};
-			id=144;
+			id=2673;
 			type="O_Heli_Light_02_dynamicLoadout_F";
 		};
-		class Item112
+		class Item245
 		{
 			dataType="Group";
 			side="East";
@@ -3919,14 +14993,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2350.7874,5.0014391,1368.7529};
+						position[]={2350.7871,5.0014391,1368.7531};
 					};
 					side="East";
 					flags=6;
 					class Attributes
 					{
 					};
-					id=149;
+					id=2675;
 					type="O_Soldier_F";
 				};
 			};
@@ -3945,8 +15019,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=149;
-						item1=148;
+						item0=2675;
+						item1=2676;
 						class CustomData
 						{
 							role=2;
@@ -3955,14 +15029,14 @@ class Mission
 					};
 				};
 			};
-			id=147;
+			id=2674;
 		};
-		class Item113
+		class Item246
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={2350.7874,5.7216258,1368.7026};
+				position[]={2350.7871,5.7216258,1368.7026};
 			};
 			side="East";
 			flags=6;
@@ -3970,17 +15044,17 @@ class Mission
 			{
 				skill=0.60000002;
 			};
-			id=148;
+			id=2676;
 			type="O_Mortar_01_F";
 		};
-		class Item114
+		class Item247
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
 				position[]={2353.8879,5,1349.772};
 			};
-			id=150;
+			id=2677;
 			type="SupportRequester";
 			class CustomAttributes
 			{
@@ -4120,7 +15194,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item115
+		class Item248
 		{
 			dataType="Group";
 			side="East";
@@ -4139,7 +15213,7 @@ class Mission
 					class Attributes
 					{
 					};
-					id=155;
+					id=2679;
 					type="O_helipilot_F";
 				};
 				class Item1
@@ -4154,7 +15228,7 @@ class Mission
 					class Attributes
 					{
 					};
-					id=156;
+					id=2680;
 					type="O_helipilot_F";
 				};
 			};
@@ -4173,8 +15247,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=155;
-						item1=154;
+						item0=2679;
+						item1=2681;
 						class CustomData
 						{
 							role=1;
@@ -4183,8 +15257,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=156;
-						item1=154;
+						item0=2680;
+						item1=2681;
 						class CustomData
 						{
 							role=2;
@@ -4193,9 +15267,9 @@ class Mission
 					};
 				};
 			};
-			id=153;
+			id=2678;
 		};
-		class Item116
+		class Item249
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4210,10 +15284,10 @@ class Mission
 				receiveRemoteTargets=1;
 				pylons="PylonWeapon_2000Rnd_65x39_belt;PylonRack_12Rnd_missiles;";
 			};
-			id=154;
+			id=2681;
 			type="O_Heli_Light_02_dynamicLoadout_F";
 		};
-		class Item117
+		class Item250
 		{
 			dataType="Group";
 			side="East";
@@ -4232,7 +15306,7 @@ class Mission
 					class Attributes
 					{
 					};
-					id=159;
+					id=2683;
 					type="O_Soldier_F";
 				};
 			};
@@ -4251,8 +15325,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=159;
-						item1=158;
+						item0=2683;
+						item1=2684;
 						class CustomData
 						{
 							role=2;
@@ -4261,9 +15335,9 @@ class Mission
 					};
 				};
 			};
-			id=157;
+			id=2682;
 		};
-		class Item118
+		class Item251
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4276,17 +15350,17 @@ class Mission
 			{
 				skill=0.60000002;
 			};
-			id=158;
+			id=2684;
 			type="O_Mortar_01_F";
 		};
-		class Item119
+		class Item252
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1384.1157,5,761.96008};
+				position[]={1356.8848,5,1362.511};
 			};
-			id=160;
+			id=2685;
 			type="SupportRequester";
 			class CustomAttributes
 			{
@@ -4426,7 +15500,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item120
+		class Item253
 		{
 			dataType="Group";
 			side="Independent";
@@ -4438,14 +15512,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1386.1177,5.0014391,755.87048};
+						position[]={1358.887,5.0014391,1356.421};
 					};
 					side="Independent";
 					flags=6;
 					class Attributes
 					{
 					};
-					id=165;
+					id=2687;
 					type="I_helipilot_F";
 				};
 				class Item1
@@ -4453,14 +15527,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1386.1177,5.0014391,755.87048};
+						position[]={1358.887,5.0014391,1356.421};
 					};
 					side="Independent";
 					flags=4;
 					class Attributes
 					{
 					};
-					id=166;
+					id=2688;
 					type="I_helipilot_F";
 				};
 			};
@@ -4479,8 +15553,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=165;
-						item1=164;
+						item0=2687;
+						item1=2689;
 						class CustomData
 						{
 							role=1;
@@ -4489,8 +15563,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=166;
-						item1=164;
+						item0=2688;
+						item1=2689;
 						class CustomData
 						{
 							role=2;
@@ -4499,14 +15573,14 @@ class Mission
 					};
 				};
 			};
-			id=163;
+			id=2686;
 		};
-		class Item121
+		class Item254
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1386.1177,6.5310755,755.82043};
+				position[]={1358.887,6.5310755,1356.371};
 			};
 			side="Independent";
 			flags=6;
@@ -4515,10 +15589,10 @@ class Mission
 				skill=0.60000002;
 				receiveRemoteTargets=1;
 			};
-			id=164;
+			id=2689;
 			type="I_Heli_light_03_dynamicLoadout_F";
 		};
-		class Item122
+		class Item255
 		{
 			dataType="Group";
 			side="Independent";
@@ -4530,14 +15604,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1382.0044,5.0014391,755.89136};
+						position[]={1354.7734,5.0014391,1356.4421};
 					};
 					side="Independent";
 					flags=6;
 					class Attributes
 					{
 					};
-					id=169;
+					id=2691;
 					type="I_soldier_F";
 				};
 			};
@@ -4556,8 +15630,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=169;
-						item1=168;
+						item0=2691;
+						item1=2692;
 						class CustomData
 						{
 							role=2;
@@ -4566,14 +15640,14 @@ class Mission
 					};
 				};
 			};
-			id=167;
+			id=2690;
 		};
-		class Item123
+		class Item256
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1382.0044,5.7216258,755.84094};
+				position[]={1354.7734,5.7216258,1356.3917};
 			};
 			side="Independent";
 			flags=6;
@@ -4581,17 +15655,17 @@ class Mission
 			{
 				skill=0.60000002;
 			};
-			id=168;
+			id=2692;
 			type="I_Mortar_01_F";
 		};
-		class Item124
+		class Item257
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1384.5522,5,732.03235};
+				position[]={1357.3213,5,1332.5833};
 			};
-			id=170;
+			id=2693;
 			type="SupportRequester";
 			class CustomAttributes
 			{
@@ -4731,7 +15805,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item125
+		class Item258
 		{
 			dataType="Group";
 			side="Independent";
@@ -4743,14 +15817,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1386.6372,5.0014391,725.99646};
+						position[]={1359.406,5.0014391,1326.547};
 					};
 					side="Independent";
 					flags=6;
 					class Attributes
 					{
 					};
-					id=175;
+					id=2695;
 					type="I_helipilot_F";
 				};
 				class Item1
@@ -4758,14 +15832,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1386.6372,5.0014391,725.99646};
+						position[]={1359.406,5.0014391,1326.547};
 					};
 					side="Independent";
 					flags=4;
 					class Attributes
 					{
 					};
-					id=176;
+					id=2696;
 					type="I_helipilot_F";
 				};
 			};
@@ -4784,8 +15858,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=175;
-						item1=174;
+						item0=2695;
+						item1=2697;
 						class CustomData
 						{
 							role=1;
@@ -4794,8 +15868,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=176;
-						item1=174;
+						item0=2696;
+						item1=2697;
 						class CustomData
 						{
 							role=2;
@@ -4804,14 +15878,14 @@ class Mission
 					};
 				};
 			};
-			id=173;
+			id=2694;
 		};
-		class Item126
+		class Item259
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1386.6372,6.5310755,725.94641};
+				position[]={1359.406,6.5310755,1326.4969};
 			};
 			side="Independent";
 			flags=6;
@@ -4820,10 +15894,10 @@ class Mission
 				skill=0.60000002;
 				receiveRemoteTargets=1;
 			};
-			id=174;
+			id=2697;
 			type="I_Heli_light_03_dynamicLoadout_F";
 		};
-		class Item127
+		class Item260
 		{
 			dataType="Group";
 			side="Independent";
@@ -4835,14 +15909,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1382.479,5.0014391,725.98999};
+						position[]={1355.248,5.0014391,1326.541};
 					};
 					side="Independent";
 					flags=6;
 					class Attributes
 					{
 					};
-					id=179;
+					id=2699;
 					type="I_soldier_F";
 				};
 			};
@@ -4861,8 +15935,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=179;
-						item1=178;
+						item0=2699;
+						item1=2700;
 						class CustomData
 						{
 							role=2;
@@ -4871,14 +15945,14 @@ class Mission
 					};
 				};
 			};
-			id=177;
+			id=2698;
 		};
-		class Item128
+		class Item261
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1382.479,5.7216258,725.93958};
+				position[]={1355.248,5.7216258,1326.4906};
 			};
 			side="Independent";
 			flags=6;
@@ -4886,17 +15960,17 @@ class Mission
 			{
 				skill=0.60000002;
 			};
-			id=178;
+			id=2700;
 			type="I_Mortar_01_F";
 		};
-		class Item129
+		class Item262
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
 				position[]={411.24136,5,1347.6611};
 			};
-			id=180;
+			id=2701;
 			type="SupportRequester";
 			class CustomAttributes
 			{
@@ -5036,7 +16110,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item130
+		class Item263
 		{
 			dataType="Group";
 			side="West";
@@ -5055,7 +16129,7 @@ class Mission
 					class Attributes
 					{
 					};
-					id=185;
+					id=2703;
 					type="B_Soldier_F";
 				};
 			};
@@ -5074,8 +16148,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=185;
-						item1=184;
+						item0=2703;
+						item1=2704;
 						class CustomData
 						{
 							role=2;
@@ -5084,9 +16158,9 @@ class Mission
 					};
 				};
 			};
-			id=183;
+			id=2702;
 		};
-		class Item131
+		class Item264
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5099,10 +16173,10 @@ class Mission
 			{
 				skill=0.60000002;
 			};
-			id=184;
+			id=2704;
 			type="B_Mortar_01_F";
 		};
-		class Item132
+		class Item265
 		{
 			dataType="Group";
 			side="West";
@@ -5121,7 +16195,7 @@ class Mission
 					class Attributes
 					{
 					};
-					id=188;
+					id=2706;
 					type="B_Helipilot_F";
 				};
 				class Item1
@@ -5136,7 +16210,7 @@ class Mission
 					class Attributes
 					{
 					};
-					id=189;
+					id=2707;
 					type="B_Helipilot_F";
 				};
 			};
@@ -5155,8 +16229,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=188;
-						item1=187;
+						item0=2706;
+						item1=2708;
 						class CustomData
 						{
 							role=1;
@@ -5165,8 +16239,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=189;
-						item1=187;
+						item0=2707;
+						item1=2708;
 						class CustomData
 						{
 							role=2;
@@ -5175,10 +16249,10 @@ class Mission
 					};
 				};
 			};
-			id=186;
+			id=2705;
 			atlOffset=-0.37890196;
 		};
-		class Item133
+		class Item266
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5192,11 +16266,11 @@ class Mission
 				skill=0.60000002;
 				receiveRemoteTargets=1;
 			};
-			id=187;
+			id=2708;
 			type="B_Heli_Light_01_dynamicLoadout_F";
 			atlOffset=-0.37890196;
 		};
-		class Item134
+		class Item267
 		{
 			dataType="Group";
 			side="West";
@@ -5222,7 +16296,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=191;
+					id=2710;
 					type="B_officer_F";
 					class CustomAttributes
 					{
@@ -5267,7 +16341,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=192;
+					id=2711;
 					type="B_officer_F";
 					class CustomAttributes
 					{
@@ -5311,7 +16385,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=193;
+					id=2712;
 					type="B_soldier_UAV_F";
 					class CustomAttributes
 					{
@@ -5355,7 +16429,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=194;
+					id=2713;
 					type="B_medic_F";
 					class CustomAttributes
 					{
@@ -5386,7 +16460,7 @@ class Mission
 			{
 				name="GrpNATO_CO";
 			};
-			id=190;
+			id=2709;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -5411,7 +16485,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item135
+		class Item268
 		{
 			dataType="Group";
 			side="West";
@@ -5437,7 +16511,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=196;
+					id=2715;
 					type="B_officer_F";
 					class CustomAttributes
 					{
@@ -5482,7 +16556,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=197;
+					id=2716;
 					type="B_officer_F";
 					class CustomAttributes
 					{
@@ -5526,7 +16600,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=198;
+					id=2717;
 					type="B_soldier_UAV_F";
 					class CustomAttributes
 					{
@@ -5570,7 +16644,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=199;
+					id=2718;
 					type="B_medic_F";
 					class CustomAttributes
 					{
@@ -5601,7 +16675,7 @@ class Mission
 			{
 				name="GrpNATO_DC";
 			};
-			id=195;
+			id=2714;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -5626,7 +16700,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item136
+		class Item269
 		{
 			dataType="Group";
 			side="West";
@@ -5638,7 +16712,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={431.17886,5.0014391,1304.6467};
+						position[]={431.17899,4.8214393,1304.6471};
 					};
 					side="West";
 					flags=6;
@@ -5652,15 +16726,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=201;
+					id=2720;
 					type="B_crew_F";
+					atlOffset=-0.17999983;
 				};
 				class Item1
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={431.17886,5.0014391,1304.6467};
+						position[]={431.17899,4.8214393,1304.6471};
 					};
 					side="West";
 					flags=4;
@@ -5674,15 +16749,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=202;
+					id=2721;
 					type="B_crew_F";
+					atlOffset=-0.17999983;
 				};
 				class Item2
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={431.17886,5.0014391,1304.6467};
+						position[]={431.17899,4.8214393,1304.6471};
 					};
 					side="West";
 					flags=4;
@@ -5695,8 +16771,9 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=203;
+					id=2722;
 					type="B_crew_F";
+					atlOffset=-0.17999983;
 				};
 			};
 			class Attributes
@@ -5715,8 +16792,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=201;
-						item1=13;
+						item0=2720;
+						item1=2564;
 						class CustomData
 						{
 							role=2;
@@ -5726,8 +16803,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=202;
-						item1=13;
+						item0=2721;
+						item1=2564;
 						class CustomData
 						{
 							role=2;
@@ -5737,8 +16814,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=203;
-						item1=13;
+						item0=2722;
+						item1=2564;
 						class CustomData
 						{
 							role=1;
@@ -5746,7 +16823,7 @@ class Mission
 					};
 				};
 			};
-			id=200;
+			id=2719;
 			atlOffset=-0.17999983;
 			class CustomAttributes
 			{
@@ -5772,7 +16849,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item137
+		class Item270
 		{
 			dataType="Group";
 			side="West";
@@ -5798,8 +16875,31 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=205;
+					id=2724;
 					type="B_Soldier_SL_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male09ENG";
+								};
+							};
+						};
+						nAttributes=1;
+					};
 				};
 				class Item1
 				{
@@ -5819,15 +16919,38 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=206;
+					id=2725;
 					type="B_medic_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male09ENG";
+								};
+							};
+						};
+						nAttributes=1;
+					};
 				};
 			};
 			class Attributes
 			{
 				name="GrpNATO_ASL";
 			};
-			id=204;
+			id=2723;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -5852,7 +16975,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item138
+		class Item271
 		{
 			dataType="Group";
 			side="West";
@@ -5878,7 +17001,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=208;
+					id=2727;
 					type="B_Soldier_TL_F";
 				};
 				class Item1
@@ -5900,7 +17023,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=209;
+					id=2728;
 					type="B_soldier_AR_F";
 				};
 				class Item2
@@ -5922,7 +17045,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=210;
+					id=2729;
 					type="B_soldier_AR_F";
 				};
 				class Item3
@@ -5944,7 +17067,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=211;
+					id=2730;
 					type="B_soldier_LAT_F";
 				};
 				class Item4
@@ -5965,7 +17088,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=212;
+					id=2731;
 					type="B_Soldier_F";
 				};
 				class Item5
@@ -5986,7 +17109,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=213;
+					id=2732;
 					type="B_Soldier_F";
 				};
 			};
@@ -5994,7 +17117,7 @@ class Mission
 			{
 				name="GrpNATO_A1";
 			};
-			id=207;
+			id=2726;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -6019,7 +17142,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item139
+		class Item272
 		{
 			dataType="Group";
 			side="West";
@@ -6045,7 +17168,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=215;
+					id=2734;
 					type="B_Soldier_TL_F";
 				};
 				class Item1
@@ -6067,7 +17190,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=216;
+					id=2735;
 					type="B_soldier_AR_F";
 				};
 				class Item2
@@ -6089,7 +17212,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=217;
+					id=2736;
 					type="B_soldier_AR_F";
 				};
 				class Item3
@@ -6111,7 +17234,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=218;
+					id=2737;
 					type="B_soldier_LAT_F";
 				};
 				class Item4
@@ -6132,7 +17255,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=219;
+					id=2738;
 					type="B_Soldier_F";
 				};
 				class Item5
@@ -6153,7 +17276,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=220;
+					id=2739;
 					type="B_Soldier_F";
 				};
 			};
@@ -6161,7 +17284,7 @@ class Mission
 			{
 				name="GrpNATO_A2";
 			};
-			id=214;
+			id=2733;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -6186,7 +17309,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item140
+		class Item273
 		{
 			dataType="Group";
 			side="West";
@@ -6198,7 +17321,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={470.42007,5.0014391,1304.22};
+						position[]={470.42001,4.8214393,1304.2201};
 					};
 					side="West";
 					flags=6;
@@ -6212,15 +17335,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=222;
+					id=2741;
 					type="B_crew_F";
+					atlOffset=-0.17999983;
 				};
 				class Item1
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={470.42007,5.0014391,1304.22};
+						position[]={470.42001,4.8214393,1304.2201};
 					};
 					side="West";
 					flags=4;
@@ -6234,15 +17358,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=223;
+					id=2742;
 					type="B_crew_F";
+					atlOffset=-0.17999983;
 				};
 				class Item2
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={470.42007,5.0014391,1304.22};
+						position[]={470.42001,4.8214393,1304.2201};
 					};
 					side="West";
 					flags=4;
@@ -6255,8 +17380,9 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=224;
+					id=2743;
 					type="B_crew_F";
+					atlOffset=-0.17999983;
 				};
 			};
 			class Attributes
@@ -6275,8 +17401,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=222;
-						item1=10;
+						item0=2741;
+						item1=2561;
 						class CustomData
 						{
 							role=2;
@@ -6286,8 +17412,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=223;
-						item1=10;
+						item0=2742;
+						item1=2561;
 						class CustomData
 						{
 							role=2;
@@ -6297,8 +17423,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=224;
-						item1=10;
+						item0=2743;
+						item1=2561;
 						class CustomData
 						{
 							role=1;
@@ -6306,7 +17432,7 @@ class Mission
 					};
 				};
 			};
-			id=221;
+			id=2740;
 			atlOffset=-0.17999983;
 			class CustomAttributes
 			{
@@ -6332,7 +17458,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item141
+		class Item274
 		{
 			dataType="Group";
 			side="West";
@@ -6358,7 +17484,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=226;
+					id=2745;
 					type="B_Soldier_SL_F";
 				};
 				class Item1
@@ -6379,7 +17505,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=227;
+					id=2746;
 					type="B_medic_F";
 				};
 			};
@@ -6387,7 +17513,7 @@ class Mission
 			{
 				name="GrpNATO_BSL";
 			};
-			id=225;
+			id=2744;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -6412,7 +17538,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item142
+		class Item275
 		{
 			dataType="Group";
 			side="West";
@@ -6438,7 +17564,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=229;
+					id=2748;
 					type="B_Soldier_TL_F";
 				};
 				class Item1
@@ -6460,7 +17586,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=230;
+					id=2749;
 					type="B_soldier_AR_F";
 				};
 				class Item2
@@ -6482,7 +17608,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=231;
+					id=2750;
 					type="B_soldier_AR_F";
 				};
 				class Item3
@@ -6504,7 +17630,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=232;
+					id=2751;
 					type="B_soldier_LAT_F";
 				};
 				class Item4
@@ -6525,7 +17651,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=233;
+					id=2752;
 					type="B_Soldier_F";
 				};
 				class Item5
@@ -6546,7 +17672,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=234;
+					id=2753;
 					type="B_Soldier_F";
 				};
 			};
@@ -6554,7 +17680,7 @@ class Mission
 			{
 				name="GrpNATO_B1";
 			};
-			id=228;
+			id=2747;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -6579,7 +17705,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item143
+		class Item276
 		{
 			dataType="Group";
 			side="West";
@@ -6605,7 +17731,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=236;
+					id=2755;
 					type="B_Soldier_TL_F";
 				};
 				class Item1
@@ -6627,7 +17753,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=237;
+					id=2756;
 					type="B_soldier_AR_F";
 				};
 				class Item2
@@ -6649,7 +17775,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=238;
+					id=2757;
 					type="B_soldier_AR_F";
 				};
 				class Item3
@@ -6671,7 +17797,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=239;
+					id=2758;
 					type="B_soldier_LAT_F";
 				};
 				class Item4
@@ -6692,7 +17818,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=240;
+					id=2759;
 					type="B_Soldier_F";
 				};
 				class Item5
@@ -6713,7 +17839,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=241;
+					id=2760;
 					type="B_Soldier_F";
 				};
 			};
@@ -6721,7 +17847,7 @@ class Mission
 			{
 				name="GrpNATO_B2";
 			};
-			id=235;
+			id=2754;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -6746,7 +17872,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item144
+		class Item277
 		{
 			dataType="Group";
 			side="West";
@@ -6758,7 +17884,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={517.84583,5.0014391,1301.2805};
+						position[]={517.84601,4.8214393,1301.28};
 					};
 					side="West";
 					flags=6;
@@ -6772,15 +17898,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=243;
+					id=2762;
 					type="B_crew_F";
+					atlOffset=-0.17999983;
 				};
 				class Item1
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={517.84583,5.0014391,1301.2805};
+						position[]={517.84601,4.8214393,1301.28};
 					};
 					side="West";
 					flags=4;
@@ -6794,15 +17921,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=244;
+					id=2763;
 					type="B_crew_F";
+					atlOffset=-0.17999983;
 				};
 				class Item2
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={517.84583,5.0014391,1301.2805};
+						position[]={517.84601,4.8214393,1301.28};
 					};
 					side="West";
 					flags=4;
@@ -6815,8 +17943,9 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=245;
+					id=2764;
 					type="B_crew_F";
+					atlOffset=-0.17999983;
 				};
 			};
 			class Attributes
@@ -6835,8 +17964,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=243;
-						item1=11;
+						item0=2762;
+						item1=2562;
 						class CustomData
 						{
 							role=2;
@@ -6846,8 +17975,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=244;
-						item1=11;
+						item0=2763;
+						item1=2562;
 						class CustomData
 						{
 							role=2;
@@ -6857,8 +17986,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=245;
-						item1=11;
+						item0=2764;
+						item1=2562;
 						class CustomData
 						{
 							role=1;
@@ -6866,7 +17995,7 @@ class Mission
 					};
 				};
 			};
-			id=242;
+			id=2761;
 			atlOffset=-0.17999983;
 			class CustomAttributes
 			{
@@ -6892,7 +18021,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item145
+		class Item278
 		{
 			dataType="Group";
 			side="West";
@@ -6918,7 +18047,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=247;
+					id=2766;
 					type="B_Soldier_SL_F";
 					class CustomAttributes
 					{
@@ -6962,7 +18091,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=248;
+					id=2767;
 					type="B_medic_F";
 				};
 			};
@@ -6970,7 +18099,7 @@ class Mission
 			{
 				name="GrpNATO_CSL";
 			};
-			id=246;
+			id=2765;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -6995,7 +18124,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item146
+		class Item279
 		{
 			dataType="Group";
 			side="West";
@@ -7021,7 +18150,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=250;
+					id=2769;
 					type="B_Soldier_TL_F";
 				};
 				class Item1
@@ -7043,7 +18172,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=251;
+					id=2770;
 					type="B_soldier_AR_F";
 				};
 				class Item2
@@ -7065,7 +18194,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=252;
+					id=2771;
 					type="B_soldier_AR_F";
 				};
 				class Item3
@@ -7087,7 +18216,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=253;
+					id=2772;
 					type="B_soldier_LAT_F";
 				};
 				class Item4
@@ -7108,7 +18237,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=254;
+					id=2773;
 					type="B_Soldier_F";
 				};
 				class Item5
@@ -7129,7 +18258,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=255;
+					id=2774;
 					type="B_Soldier_F";
 				};
 			};
@@ -7137,7 +18266,7 @@ class Mission
 			{
 				name="GrpNATO_C1";
 			};
-			id=249;
+			id=2768;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -7162,7 +18291,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item147
+		class Item280
 		{
 			dataType="Group";
 			side="West";
@@ -7188,7 +18317,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=257;
+					id=2776;
 					type="B_Soldier_TL_F";
 				};
 				class Item1
@@ -7210,7 +18339,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=258;
+					id=2777;
 					type="B_soldier_AR_F";
 				};
 				class Item2
@@ -7232,7 +18361,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=259;
+					id=2778;
 					type="B_soldier_AR_F";
 				};
 				class Item3
@@ -7254,7 +18383,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=260;
+					id=2779;
 					type="B_soldier_LAT_F";
 				};
 				class Item4
@@ -7275,7 +18404,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=261;
+					id=2780;
 					type="B_Soldier_F";
 				};
 				class Item5
@@ -7296,7 +18425,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=262;
+					id=2781;
 					type="B_Soldier_F";
 				};
 			};
@@ -7304,7 +18433,7 @@ class Mission
 			{
 				name="GrpNATO_C2";
 			};
-			id=256;
+			id=2775;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -7329,7 +18458,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item148
+		class Item281
 		{
 			dataType="Group";
 			side="West";
@@ -7341,7 +18470,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={560.05579,5.0014391,1302.509};
+						position[]={560.05603,4.8214393,1302.509};
 					};
 					side="West";
 					flags=6;
@@ -7355,15 +18484,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=264;
+					id=2783;
 					type="B_crew_F";
+					atlOffset=-0.17999983;
 				};
 				class Item1
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={560.05579,5.0014391,1302.509};
+						position[]={560.05603,4.8214393,1302.509};
 					};
 					side="West";
 					flags=4;
@@ -7377,15 +18507,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=265;
+					id=2784;
 					type="B_crew_F";
+					atlOffset=-0.17999983;
 				};
 				class Item2
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={560.05579,5.0014391,1302.509};
+						position[]={560.05603,4.8214393,1302.509};
 					};
 					side="West";
 					flags=4;
@@ -7398,8 +18529,9 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=266;
+					id=2785;
 					type="B_crew_F";
+					atlOffset=-0.17999983;
 				};
 			};
 			class Attributes
@@ -7418,8 +18550,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=264;
-						item1=12;
+						item0=2783;
+						item1=2563;
 						class CustomData
 						{
 							role=2;
@@ -7429,8 +18561,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=265;
-						item1=12;
+						item0=2784;
+						item1=2563;
 						class CustomData
 						{
 							role=2;
@@ -7440,8 +18572,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=266;
-						item1=12;
+						item0=2785;
+						item1=2563;
 						class CustomData
 						{
 							role=1;
@@ -7449,7 +18581,7 @@ class Mission
 					};
 				};
 			};
-			id=263;
+			id=2782;
 			atlOffset=-0.17999983;
 			class CustomAttributes
 			{
@@ -7475,7 +18607,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item149
+		class Item282
 		{
 			dataType="Group";
 			side="West";
@@ -7501,7 +18633,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=268;
+					id=2787;
 					type="B_Soldier_TL_F";
 				};
 				class Item1
@@ -7522,7 +18654,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=269;
+					id=2788;
 					type="B_soldier_AR_F";
 				};
 				class Item2
@@ -7544,7 +18676,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1209;
+					id=2789;
 					type="B_soldier_AAR_F";
 				};
 			};
@@ -7552,7 +18684,7 @@ class Mission
 			{
 				name="GrpNATO_MMG1";
 			};
-			id=267;
+			id=2786;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -7577,7 +18709,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item150
+		class Item283
 		{
 			dataType="Group";
 			side="West";
@@ -7603,7 +18735,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=271;
+					id=2791;
 					type="B_Soldier_TL_F";
 				};
 				class Item1
@@ -7624,7 +18756,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=272;
+					id=2792;
 					type="B_soldier_AR_F";
 				};
 				class Item2
@@ -7646,7 +18778,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1210;
+					id=2793;
 					type="B_soldier_AAR_F";
 				};
 			};
@@ -7654,7 +18786,7 @@ class Mission
 			{
 				name="GrpNATO_MMG2";
 			};
-			id=270;
+			id=2790;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -7679,7 +18811,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item151
+		class Item284
 		{
 			dataType="Group";
 			side="West";
@@ -7705,7 +18837,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=274;
+					id=2795;
 					type="B_Soldier_TL_F";
 				};
 				class Item1
@@ -7726,7 +18858,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=275;
+					id=2796;
 					type="B_soldier_AT_F";
 					atlOffset=0.035766125;
 				};
@@ -7749,7 +18881,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1211;
+					id=2797;
 					type="B_soldier_AAT_F";
 				};
 			};
@@ -7757,7 +18889,7 @@ class Mission
 			{
 				name="GrpNATO_MAT1";
 			};
-			id=273;
+			id=2794;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -7782,7 +18914,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item152
+		class Item285
 		{
 			dataType="Group";
 			side="West";
@@ -7808,7 +18940,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=277;
+					id=2799;
 					type="B_Soldier_TL_F";
 				};
 				class Item1
@@ -7830,7 +18962,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=278;
+					id=2800;
 					type="B_soldier_AT_F";
 				};
 				class Item2
@@ -7852,7 +18984,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1212;
+					id=2801;
 					type="B_soldier_AAT_F";
 				};
 			};
@@ -7860,7 +18992,7 @@ class Mission
 			{
 				name="GrpNATO_MAT2";
 			};
-			id=276;
+			id=2798;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -7885,7 +19017,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item153
+		class Item286
 		{
 			dataType="Group";
 			side="West";
@@ -7911,7 +19043,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=280;
+					id=2803;
 					type="B_Soldier_TL_F";
 				};
 				class Item1
@@ -7932,7 +19064,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=281;
+					id=2804;
 					type="B_support_MG_F";
 				};
 			};
@@ -7940,7 +19072,7 @@ class Mission
 			{
 				name="GrpNATO_HMG1";
 			};
-			id=279;
+			id=2802;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -7965,7 +19097,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item154
+		class Item287
 		{
 			dataType="Group";
 			side="West";
@@ -7991,7 +19123,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=283;
+					id=2806;
 					type="B_Soldier_TL_F";
 				};
 				class Item1
@@ -8013,7 +19145,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=284;
+					id=2807;
 					type="B_soldier_AT_F";
 				};
 				class Item2
@@ -8035,7 +19167,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1213;
+					id=2808;
 					type="B_soldier_AAT_F";
 				};
 			};
@@ -8043,7 +19175,7 @@ class Mission
 			{
 				name="GrpNATO_HAT1";
 			};
-			id=282;
+			id=2805;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -8068,7 +19200,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item155
+		class Item288
 		{
 			dataType="Group";
 			side="West";
@@ -8094,7 +19226,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=286;
+					id=2810;
 					type="B_support_AMort_F";
 					atlOffset=0.59719753;
 				};
@@ -8116,7 +19248,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=287;
+					id=2811;
 					type="B_support_Mort_F";
 					atlOffset=0.6367197;
 				};
@@ -8125,7 +19257,7 @@ class Mission
 			{
 				name="GrpNATO_MTR1";
 			};
-			id=285;
+			id=2809;
 			atlOffset=0.59719753;
 			class CustomAttributes
 			{
@@ -8151,7 +19283,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item156
+		class Item289
 		{
 			dataType="Group";
 			side="West";
@@ -8177,7 +19309,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=289;
+					id=2813;
 					type="B_soldier_AAA_F";
 					atlOffset=0.71500015;
 				};
@@ -8199,7 +19331,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=290;
+					id=2814;
 					type="B_soldier_AA_F";
 					atlOffset=0.79047394;
 				};
@@ -8221,7 +19353,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1160;
+					id=2815;
 					type="B_soldier_AAA_F";
 					atlOffset=0.71500015;
 				};
@@ -8230,7 +19362,7 @@ class Mission
 			{
 				name="GrpNATO_MSAM1";
 			};
-			id=288;
+			id=2812;
 			atlOffset=0.71500015;
 			class CustomAttributes
 			{
@@ -8256,7 +19388,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item157
+		class Item290
 		{
 			dataType="Group";
 			side="West";
@@ -8282,7 +19414,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=292;
+					id=2817;
 					type="B_soldier_AAA_F";
 					atlOffset=0.72082043;
 				};
@@ -8304,7 +19436,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=293;
+					id=2818;
 					type="B_soldier_AA_F";
 					atlOffset=0.71391106;
 				};
@@ -8313,7 +19445,7 @@ class Mission
 			{
 				name="GrpNATO_HSAM1";
 			};
-			id=291;
+			id=2816;
 			atlOffset=0.72082043;
 			class CustomAttributes
 			{
@@ -8339,7 +19471,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item158
+		class Item291
 		{
 			dataType="Group";
 			side="West";
@@ -8365,7 +19497,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=295;
+					id=2820;
 					type="B_spotter_F";
 					atlOffset=0.65095043;
 				};
@@ -8387,7 +19519,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=296;
+					id=2821;
 					type="B_sniper_F";
 					atlOffset=0.65321445;
 				};
@@ -8396,7 +19528,7 @@ class Mission
 			{
 				name="GrpNATO_ST1";
 			};
-			id=294;
+			id=2819;
 			atlOffset=0.65095043;
 			class CustomAttributes
 			{
@@ -8422,7 +19554,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item159
+		class Item292
 		{
 			dataType="Group";
 			side="West";
@@ -8448,7 +19580,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=298;
+					id=2823;
 					type="B_engineer_F";
 					atlOffset=0.2694006;
 				};
@@ -8470,7 +19602,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=299;
+					id=2824;
 					type="B_engineer_F";
 					atlOffset=0.10848618;
 				};
@@ -8491,7 +19623,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=300;
+					id=2825;
 					type="B_engineer_F";
 					atlOffset=0.30563259;
 				};
@@ -8513,7 +19645,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=301;
+					id=2826;
 					type="B_engineer_F";
 					atlOffset=0.093743324;
 				};
@@ -8522,7 +19654,7 @@ class Mission
 			{
 				name="GrpNATO_ENG1";
 			};
-			id=297;
+			id=2822;
 			atlOffset=0.2694006;
 			class CustomAttributes
 			{
@@ -8548,7 +19680,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item160
+		class Item293
 		{
 			dataType="Group";
 			side="West";
@@ -8574,7 +19706,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=303;
+					id=2828;
 					type="B_diver_TL_F";
 				};
 				class Item1
@@ -8596,7 +19728,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=304;
+					id=2829;
 					type="B_diver_F";
 				};
 				class Item2
@@ -8618,7 +19750,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=305;
+					id=2830;
 					type="B_diver_F";
 				};
 				class Item3
@@ -8640,7 +19772,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=306;
+					id=2831;
 					type="B_diver_F";
 				};
 			};
@@ -8648,7 +19780,7 @@ class Mission
 			{
 				name="GrpNATO_DT1";
 			};
-			id=302;
+			id=2827;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -8673,7 +19805,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item161
+		class Item294
 		{
 			dataType="Group";
 			side="West";
@@ -8685,7 +19817,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={430.91617,5.0014391,1278.9602};
+						position[]={430.91599,4.924439,1278.9601};
 					};
 					side="West";
 					flags=6;
@@ -8699,15 +19831,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=308;
+					id=2833;
 					type="B_crew_F";
+					atlOffset=-0.077000141;
 				};
 				class Item1
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={430.91617,5.0014391,1278.9602};
+						position[]={430.91599,4.924439,1278.9601};
 					};
 					side="West";
 					flags=4;
@@ -8721,15 +19854,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=309;
+					id=2834;
 					type="B_crew_F";
+					atlOffset=-0.077000141;
 				};
 				class Item2
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={430.91617,5.0014391,1278.9602};
+						position[]={430.91599,4.924439,1278.9601};
 					};
 					side="West";
 					flags=4;
@@ -8742,8 +19876,9 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=310;
+					id=2835;
 					type="B_crew_F";
+					atlOffset=-0.077000141;
 				};
 			};
 			class Attributes
@@ -8762,8 +19897,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=308;
-						item1=73;
+						item0=2833;
+						item1=2624;
 						class CustomData
 						{
 							role=2;
@@ -8773,8 +19908,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=309;
-						item1=73;
+						item0=2834;
+						item1=2624;
 						class CustomData
 						{
 							role=2;
@@ -8784,8 +19919,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=310;
-						item1=73;
+						item0=2835;
+						item1=2624;
 						class CustomData
 						{
 							role=1;
@@ -8793,8 +19928,8 @@ class Mission
 					};
 				};
 			};
-			id=307;
-			atlOffset=-0.076682091;
+			id=2832;
+			atlOffset=-0.077000141;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -8819,7 +19954,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item162
+		class Item295
 		{
 			dataType="Group";
 			side="West";
@@ -8831,7 +19966,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={470.5939,5.0014391,1279.1477};
+						position[]={470.59399,4.924439,1279.1481};
 					};
 					side="West";
 					flags=6;
@@ -8845,15 +19980,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=312;
+					id=2837;
 					type="B_crew_F";
+					atlOffset=-0.077000141;
 				};
 				class Item1
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={470.5939,5.0014391,1279.1477};
+						position[]={470.59399,4.924439,1279.1481};
 					};
 					side="West";
 					flags=4;
@@ -8867,15 +20003,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=313;
+					id=2838;
 					type="B_crew_F";
+					atlOffset=-0.077000141;
 				};
 				class Item2
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={470.5939,5.0014391,1279.1477};
+						position[]={470.59399,4.924439,1279.1481};
 					};
 					side="West";
 					flags=4;
@@ -8888,8 +20025,9 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=314;
+					id=2839;
 					type="B_crew_F";
+					atlOffset=-0.077000141;
 				};
 			};
 			class Attributes
@@ -8908,8 +20046,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=312;
-						item1=74;
+						item0=2837;
+						item1=2625;
 						class CustomData
 						{
 							role=2;
@@ -8919,8 +20057,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=313;
-						item1=74;
+						item0=2838;
+						item1=2625;
 						class CustomData
 						{
 							role=2;
@@ -8930,8 +20068,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=314;
-						item1=74;
+						item0=2839;
+						item1=2625;
 						class CustomData
 						{
 							role=1;
@@ -8939,8 +20077,8 @@ class Mission
 					};
 				};
 			};
-			id=311;
-			atlOffset=-0.076682091;
+			id=2836;
+			atlOffset=-0.077000141;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -8965,7 +20103,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item163
+		class Item296
 		{
 			dataType="Group";
 			side="West";
@@ -8977,7 +20115,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={516.48157,5.0014391,1279.7727};
+						position[]={516.48199,4.812439,1279.7731};
 					};
 					side="West";
 					flags=6;
@@ -8991,15 +20129,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=316;
+					id=2841;
 					type="B_crew_F";
+					atlOffset=-0.18900013;
 				};
 				class Item1
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={516.48157,5.0014391,1279.7727};
+						position[]={516.48199,4.812439,1279.7731};
 					};
 					side="West";
 					flags=4;
@@ -9013,15 +20152,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=317;
+					id=2842;
 					type="B_crew_F";
+					atlOffset=-0.18900013;
 				};
 				class Item2
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={516.48157,5.0014391,1279.7727};
+						position[]={516.48199,4.812439,1279.7731};
 					};
 					side="West";
 					flags=4;
@@ -9034,8 +20174,9 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=318;
+					id=2843;
 					type="B_crew_F";
+					atlOffset=-0.18900013;
 				};
 			};
 			class Attributes
@@ -9054,8 +20195,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=316;
-						item1=30;
+						item0=2841;
+						item1=2581;
 						class CustomData
 						{
 							role=2;
@@ -9065,8 +20206,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=317;
-						item1=30;
+						item0=2842;
+						item1=2581;
 						class CustomData
 						{
 							role=2;
@@ -9076,8 +20217,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=318;
-						item1=30;
+						item0=2843;
+						item1=2581;
 						class CustomData
 						{
 							role=1;
@@ -9085,8 +20226,8 @@ class Mission
 					};
 				};
 			};
-			id=315;
-			atlOffset=-0.18917751;
+			id=2840;
+			atlOffset=-0.18900013;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -9111,7 +20252,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item164
+		class Item297
 		{
 			dataType="Group";
 			side="West";
@@ -9123,7 +20264,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={432.07535,5.0014391,1248.4297};
+						position[]={432.07501,5.0014391,1248.4301};
 					};
 					side="West";
 					flags=6;
@@ -9137,7 +20278,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=320;
+					id=2845;
 					type="B_Helipilot_F";
 				};
 				class Item1
@@ -9145,7 +20286,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={432.07535,5.0014391,1248.4297};
+						position[]={432.07501,5.0014391,1248.4301};
 					};
 					side="West";
 					flags=4;
@@ -9159,7 +20300,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=321;
+					id=2846;
 					type="B_Helipilot_F";
 				};
 				class Item2
@@ -9167,7 +20308,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={432.07535,5.0014391,1248.4297};
+						position[]={432.07501,5.0014391,1248.4301};
 					};
 					side="West";
 					flags=4;
@@ -9181,7 +20322,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=322;
+					id=2847;
 					type="B_helicrew_F";
 				};
 				class Item3
@@ -9189,7 +20330,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={432.07535,5.0014391,1248.4297};
+						position[]={432.07501,5.0014391,1248.4301};
 					};
 					side="West";
 					flags=4;
@@ -9202,7 +20343,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=323;
+					id=2848;
 					type="B_helicrew_F";
 				};
 			};
@@ -9222,8 +20363,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=320;
-						item1=0;
+						item0=2845;
+						item1=2551;
 						class CustomData
 						{
 							role=1;
@@ -9232,8 +20373,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=321;
-						item1=0;
+						item0=2846;
+						item1=2551;
 						class CustomData
 						{
 							role=2;
@@ -9243,8 +20384,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=322;
-						item1=0;
+						item0=2847;
+						item1=2551;
 						class CustomData
 						{
 							role=2;
@@ -9254,8 +20395,8 @@ class Mission
 					class Item3
 					{
 						linkID=3;
-						item0=323;
-						item1=0;
+						item0=2848;
+						item1=2551;
 						class CustomData
 						{
 							role=2;
@@ -9264,7 +20405,7 @@ class Mission
 					};
 				};
 			};
-			id=319;
+			id=2844;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -9289,7 +20430,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item165
+		class Item298
 		{
 			dataType="Group";
 			side="West";
@@ -9301,7 +20442,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={432.47964,5.0014391,1220.6484};
+						position[]={432.48001,5.0014391,1220.6481};
 					};
 					side="West";
 					flags=6;
@@ -9315,7 +20456,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=325;
+					id=2850;
 					type="B_Helipilot_F";
 				};
 				class Item1
@@ -9323,7 +20464,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={432.47964,5.0014391,1220.6484};
+						position[]={432.48001,5.0014391,1220.6481};
 					};
 					side="West";
 					flags=4;
@@ -9337,7 +20478,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=326;
+					id=2851;
 					type="B_Helipilot_F";
 				};
 				class Item2
@@ -9345,7 +20486,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={432.47964,5.0014391,1220.6484};
+						position[]={432.48001,5.0014391,1220.6481};
 					};
 					side="West";
 					flags=4;
@@ -9359,7 +20500,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=327;
+					id=2852;
 					type="B_helicrew_F";
 				};
 				class Item3
@@ -9367,7 +20508,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={432.47964,5.0014391,1220.6484};
+						position[]={432.48001,5.0014391,1220.6481};
 					};
 					side="West";
 					flags=4;
@@ -9380,7 +20521,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=328;
+					id=2853;
 					type="B_helicrew_F";
 				};
 			};
@@ -9400,8 +20541,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=325;
-						item1=3;
+						item0=2850;
+						item1=2554;
 						class CustomData
 						{
 							role=1;
@@ -9410,8 +20551,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=326;
-						item1=3;
+						item0=2851;
+						item1=2554;
 						class CustomData
 						{
 							role=2;
@@ -9421,8 +20562,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=327;
-						item1=3;
+						item0=2852;
+						item1=2554;
 						class CustomData
 						{
 							role=2;
@@ -9432,8 +20573,8 @@ class Mission
 					class Item3
 					{
 						linkID=3;
-						item0=328;
-						item1=3;
+						item0=2853;
+						item1=2554;
 						class CustomData
 						{
 							role=2;
@@ -9442,7 +20583,7 @@ class Mission
 					};
 				};
 			};
-			id=324;
+			id=2849;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -9467,7 +20608,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item166
+		class Item299
 		{
 			dataType="Group";
 			side="West";
@@ -9479,7 +20620,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={467.55972,5.0014391,1249.0986};
+						position[]={467.56,5.0014391,1249.099};
 					};
 					side="West";
 					flags=6;
@@ -9493,7 +20634,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=330;
+					id=2855;
 					type="B_Helipilot_F";
 				};
 				class Item1
@@ -9501,7 +20642,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={467.55972,5.0014391,1249.0986};
+						position[]={467.56,5.0014391,1249.099};
 					};
 					side="West";
 					flags=4;
@@ -9515,7 +20656,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=331;
+					id=2856;
 					type="B_Helipilot_F";
 				};
 				class Item2
@@ -9523,7 +20664,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={467.55972,5.0014391,1249.0986};
+						position[]={467.56,5.0014391,1249.099};
 					};
 					side="West";
 					flags=4;
@@ -9537,7 +20678,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=332;
+					id=2857;
 					type="B_helicrew_F";
 				};
 				class Item3
@@ -9545,7 +20686,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={467.55972,5.0014391,1249.0986};
+						position[]={467.56,5.0014391,1249.099};
 					};
 					side="West";
 					flags=4;
@@ -9558,7 +20699,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=333;
+					id=2858;
 					type="B_helicrew_F";
 				};
 			};
@@ -9578,8 +20719,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=330;
-						item1=4;
+						item0=2855;
+						item1=2555;
 						class CustomData
 						{
 							role=1;
@@ -9588,8 +20729,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=331;
-						item1=4;
+						item0=2856;
+						item1=2555;
 						class CustomData
 						{
 							role=2;
@@ -9599,8 +20740,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=332;
-						item1=4;
+						item0=2857;
+						item1=2555;
 						class CustomData
 						{
 							role=2;
@@ -9610,8 +20751,8 @@ class Mission
 					class Item3
 					{
 						linkID=3;
-						item0=333;
-						item1=4;
+						item0=2858;
+						item1=2555;
 						class CustomData
 						{
 							role=2;
@@ -9620,8 +20761,7 @@ class Mission
 					};
 				};
 			};
-			id=329;
-			atlOffset=-1.2397766e-005;
+			id=2854;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -9646,7 +20786,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item167
+		class Item300
 		{
 			dataType="Group";
 			side="West";
@@ -9658,7 +20798,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={468.41714,5.0014391,1221.5605};
+						position[]={468.41699,5.0014391,1221.5601};
 					};
 					side="West";
 					flags=6;
@@ -9672,7 +20812,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=335;
+					id=2860;
 					type="B_Helipilot_F";
 				};
 				class Item1
@@ -9680,7 +20820,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={468.41714,5.0014391,1221.5605};
+						position[]={468.41699,5.0014391,1221.5601};
 					};
 					side="West";
 					flags=4;
@@ -9694,7 +20834,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=336;
+					id=2861;
 					type="B_Helipilot_F";
 				};
 				class Item2
@@ -9702,7 +20842,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={468.41714,5.0014391,1221.5605};
+						position[]={468.41699,5.0014391,1221.5601};
 					};
 					side="West";
 					flags=4;
@@ -9716,7 +20856,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=337;
+					id=2862;
 					type="B_helicrew_F";
 				};
 				class Item3
@@ -9724,7 +20864,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={468.41714,5.0014391,1221.5605};
+						position[]={468.41699,5.0014391,1221.5601};
 					};
 					side="West";
 					flags=4;
@@ -9737,7 +20877,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=338;
+					id=2863;
 					type="B_helicrew_F";
 				};
 			};
@@ -9757,8 +20897,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=335;
-						item1=5;
+						item0=2860;
+						item1=2556;
 						class CustomData
 						{
 							role=1;
@@ -9767,8 +20907,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=336;
-						item1=5;
+						item0=2861;
+						item1=2556;
 						class CustomData
 						{
 							role=2;
@@ -9778,8 +20918,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=337;
-						item1=5;
+						item0=2862;
+						item1=2556;
 						class CustomData
 						{
 							role=2;
@@ -9789,8 +20929,8 @@ class Mission
 					class Item3
 					{
 						linkID=3;
-						item0=338;
-						item1=5;
+						item0=2863;
+						item1=2556;
 						class CustomData
 						{
 							role=2;
@@ -9799,8 +20939,7 @@ class Mission
 					};
 				};
 			};
-			id=334;
-			atlOffset=-1.2397766e-005;
+			id=2859;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -9825,7 +20964,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item168
+		class Item301
 		{
 			dataType="Group";
 			side="West";
@@ -9837,7 +20976,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={516.71497,5.0014391,1249.3047};
+						position[]={516.71503,5.0014391,1249.3051};
 					};
 					side="West";
 					flags=6;
@@ -9851,7 +20990,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=340;
+					id=2865;
 					type="B_Helipilot_F";
 				};
 				class Item1
@@ -9859,7 +20998,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={516.71497,5.0014391,1249.3047};
+						position[]={516.71503,5.0014391,1249.3051};
 					};
 					side="West";
 					flags=4;
@@ -9873,7 +21012,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=341;
+					id=2866;
 					type="B_Helipilot_F";
 				};
 				class Item2
@@ -9881,7 +21020,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={516.71497,5.0014391,1249.3047};
+						position[]={516.71503,5.0014391,1249.3051};
 					};
 					side="West";
 					flags=4;
@@ -9895,7 +21034,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=342;
+					id=2867;
 					type="B_helicrew_F";
 				};
 				class Item3
@@ -9903,7 +21042,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={516.71497,5.0014391,1249.3047};
+						position[]={516.71503,5.0014391,1249.3051};
 					};
 					side="West";
 					flags=4;
@@ -9916,7 +21055,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=343;
+					id=2868;
 					type="B_helicrew_F";
 				};
 			};
@@ -9936,8 +21075,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=340;
-						item1=6;
+						item0=2865;
+						item1=2557;
 						class CustomData
 						{
 							role=1;
@@ -9946,8 +21085,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=341;
-						item1=6;
+						item0=2866;
+						item1=2557;
 						class CustomData
 						{
 							role=2;
@@ -9957,8 +21096,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=342;
-						item1=6;
+						item0=2867;
+						item1=2557;
 						class CustomData
 						{
 							role=2;
@@ -9968,8 +21107,8 @@ class Mission
 					class Item3
 					{
 						linkID=3;
-						item0=343;
-						item1=6;
+						item0=2868;
+						item1=2557;
 						class CustomData
 						{
 							role=2;
@@ -9978,8 +21117,7 @@ class Mission
 					};
 				};
 			};
-			id=339;
-			atlOffset=-1.2397766e-005;
+			id=2864;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -10004,7 +21142,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item169
+		class Item302
 		{
 			dataType="Group";
 			side="West";
@@ -10016,7 +21154,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={516.78723,5.0014391,1221.2979};
+						position[]={516.78699,5.0014391,1221.2981};
 					};
 					side="West";
 					flags=6;
@@ -10030,7 +21168,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=345;
+					id=2870;
 					type="B_Helipilot_F";
 				};
 				class Item1
@@ -10038,7 +21176,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={516.78723,5.0014391,1221.2979};
+						position[]={516.78699,5.0014391,1221.2981};
 					};
 					side="West";
 					flags=4;
@@ -10052,7 +21190,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=346;
+					id=2871;
 					type="B_Helipilot_F";
 				};
 				class Item2
@@ -10060,7 +21198,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={516.78723,5.0014391,1221.2979};
+						position[]={516.78699,5.0014391,1221.2981};
 					};
 					side="West";
 					flags=4;
@@ -10074,7 +21212,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=347;
+					id=2872;
 					type="B_helicrew_F";
 				};
 				class Item3
@@ -10082,7 +21220,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={516.78723,5.0014391,1221.2979};
+						position[]={516.78699,5.0014391,1221.2981};
 					};
 					side="West";
 					flags=4;
@@ -10095,7 +21233,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=348;
+					id=2873;
 					type="B_helicrew_F";
 				};
 			};
@@ -10115,8 +21253,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=345;
-						item1=7;
+						item0=2870;
+						item1=2558;
 						class CustomData
 						{
 							role=1;
@@ -10125,8 +21263,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=346;
-						item1=7;
+						item0=2871;
+						item1=2558;
 						class CustomData
 						{
 							role=2;
@@ -10136,8 +21274,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=347;
-						item1=7;
+						item0=2872;
+						item1=2558;
 						class CustomData
 						{
 							role=2;
@@ -10147,8 +21285,8 @@ class Mission
 					class Item3
 					{
 						linkID=3;
-						item0=348;
-						item1=7;
+						item0=2873;
+						item1=2558;
 						class CustomData
 						{
 							role=2;
@@ -10157,8 +21295,7 @@ class Mission
 					};
 				};
 			};
-			id=344;
-			atlOffset=-1.2397766e-005;
+			id=2869;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -10183,7 +21320,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item170
+		class Item303
 		{
 			dataType="Group";
 			side="West";
@@ -10195,7 +21332,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={562.33704,5.0014391,1249.8828};
+						position[]={562.33698,5.0014391,1249.8831};
 					};
 					side="West";
 					flags=6;
@@ -10209,7 +21346,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=350;
+					id=2875;
 					type="B_Helipilot_F";
 				};
 				class Item1
@@ -10217,7 +21354,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={562.33704,5.0014391,1249.8828};
+						position[]={562.33698,5.0014391,1249.8831};
 					};
 					side="West";
 					flags=4;
@@ -10231,7 +21368,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=351;
+					id=2876;
 					type="B_Helipilot_F";
 				};
 				class Item2
@@ -10239,7 +21376,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={562.33704,5.0014391,1249.8828};
+						position[]={562.33698,5.0014391,1249.8831};
 					};
 					side="West";
 					flags=4;
@@ -10253,7 +21390,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=352;
+					id=2877;
 					type="B_helicrew_F";
 				};
 				class Item3
@@ -10261,7 +21398,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={562.33704,5.0014391,1249.8828};
+						position[]={562.33698,5.0014391,1249.8831};
 					};
 					side="West";
 					flags=4;
@@ -10274,7 +21411,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=353;
+					id=2878;
 					type="B_helicrew_F";
 				};
 			};
@@ -10294,8 +21431,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=350;
-						item1=8;
+						item0=2875;
+						item1=2559;
 						class CustomData
 						{
 							role=1;
@@ -10304,8 +21441,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=351;
-						item1=8;
+						item0=2876;
+						item1=2559;
 						class CustomData
 						{
 							role=2;
@@ -10315,8 +21452,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=352;
-						item1=8;
+						item0=2877;
+						item1=2559;
 						class CustomData
 						{
 							role=2;
@@ -10326,8 +21463,8 @@ class Mission
 					class Item3
 					{
 						linkID=3;
-						item0=353;
-						item1=8;
+						item0=2878;
+						item1=2559;
 						class CustomData
 						{
 							role=2;
@@ -10336,8 +21473,7 @@ class Mission
 					};
 				};
 			};
-			id=349;
-			atlOffset=-1.2397766e-005;
+			id=2874;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -10362,7 +21498,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item171
+		class Item304
 		{
 			dataType="Group";
 			side="West";
@@ -10374,7 +21510,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={563.22864,5.0014391,1222.377};
+						position[]={563.229,5.0014391,1222.3771};
 					};
 					side="West";
 					flags=6;
@@ -10388,7 +21524,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=355;
+					id=2880;
 					type="B_Helipilot_F";
 				};
 				class Item1
@@ -10396,7 +21532,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={563.22864,5.0014391,1222.377};
+						position[]={563.229,5.0014391,1222.3771};
 					};
 					side="West";
 					flags=4;
@@ -10410,7 +21546,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=356;
+					id=2881;
 					type="B_Helipilot_F";
 				};
 				class Item2
@@ -10418,7 +21554,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={563.22864,5.0014391,1222.377};
+						position[]={563.229,5.0014391,1222.3771};
 					};
 					side="West";
 					flags=4;
@@ -10432,7 +21568,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=357;
+					id=2882;
 					type="B_helicrew_F";
 				};
 				class Item3
@@ -10440,7 +21576,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={563.22864,5.0014391,1222.377};
+						position[]={563.229,5.0014391,1222.3771};
 					};
 					side="West";
 					flags=4;
@@ -10453,7 +21589,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=358;
+					id=2883;
 					type="B_helicrew_F";
 				};
 			};
@@ -10473,8 +21609,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=355;
-						item1=9;
+						item0=2880;
+						item1=2560;
 						class CustomData
 						{
 							role=1;
@@ -10483,8 +21619,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=356;
-						item1=9;
+						item0=2881;
+						item1=2560;
 						class CustomData
 						{
 							role=2;
@@ -10494,8 +21630,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=357;
-						item1=9;
+						item0=2882;
+						item1=2560;
 						class CustomData
 						{
 							role=2;
@@ -10505,8 +21641,8 @@ class Mission
 					class Item3
 					{
 						linkID=3;
-						item0=358;
-						item1=9;
+						item0=2883;
+						item1=2560;
 						class CustomData
 						{
 							role=2;
@@ -10515,8 +21651,7 @@ class Mission
 					};
 				};
 			};
-			id=354;
-			atlOffset=-1.2397766e-005;
+			id=2879;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -10541,7 +21676,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item172
+		class Item305
 		{
 			dataType="Group";
 			side="West";
@@ -10553,7 +21688,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={431.90445,5.0014391,1193.7559};
+						position[]={431.90399,5.0114393,1193.7561};
 					};
 					side="West";
 					flags=6;
@@ -10567,15 +21702,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=360;
+					id=2885;
 					type="B_Helipilot_F";
+					atlOffset=0.010000229;
 				};
 				class Item1
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={431.90445,5.0014391,1193.7559};
+						position[]={431.90399,5.0114393,1193.7561};
 					};
 					side="West";
 					flags=4;
@@ -10589,8 +21725,9 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=361;
+					id=2886;
 					type="B_Helipilot_F";
+					atlOffset=0.010000229;
 				};
 			};
 			class Attributes
@@ -10609,8 +21746,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=360;
-						item1=14;
+						item0=2885;
+						item1=2565;
 						class CustomData
 						{
 							role=1;
@@ -10619,8 +21756,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=361;
-						item1=14;
+						item0=2886;
+						item1=2565;
 						class CustomData
 						{
 							role=2;
@@ -10629,8 +21766,8 @@ class Mission
 					};
 				};
 			};
-			id=359;
-			atlOffset=0.009988308;
+			id=2884;
+			atlOffset=0.010000229;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -10655,7 +21792,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item173
+		class Item306
 		{
 			dataType="Group";
 			side="East";
@@ -10682,7 +21819,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=368;
+					id=2888;
 					type="O_officer_F";
 					class CustomAttributes
 					{
@@ -10727,7 +21864,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=369;
+					id=2889;
 					type="O_officer_F";
 					class CustomAttributes
 					{
@@ -10771,7 +21908,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=370;
+					id=2890;
 					type="O_soldier_UAV_F";
 					class CustomAttributes
 					{
@@ -10815,7 +21952,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=371;
+					id=2891;
 					type="O_medic_F";
 					class CustomAttributes
 					{
@@ -10846,7 +21983,7 @@ class Mission
 			{
 				name="GrpCSAT_CO";
 			};
-			id=367;
+			id=2887;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -10871,7 +22008,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item174
+		class Item307
 		{
 			dataType="Group";
 			side="East";
@@ -10898,7 +22035,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=373;
+					id=2893;
 					type="O_officer_F";
 				};
 				class Item1
@@ -10921,7 +22058,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=374;
+					id=2894;
 					type="O_officer_F";
 				};
 				class Item2
@@ -10942,7 +22079,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=375;
+					id=2895;
 					type="O_soldier_UAV_F";
 					class CustomAttributes
 					{
@@ -10986,7 +22123,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=376;
+					id=2896;
 					type="O_medic_F";
 				};
 			};
@@ -10994,7 +22131,7 @@ class Mission
 			{
 				name="GrpCSAT_DC";
 			};
-			id=372;
+			id=2892;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -11019,7 +22156,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item175
+		class Item308
 		{
 			dataType="Group";
 			side="East";
@@ -11031,7 +22168,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2381.1594,5.0014391,1301.3689};
+						position[]={2381.1589,5.0014391,1301.369};
 					};
 					side="East";
 					flags=4;
@@ -11045,7 +22182,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=379;
+					id=2898;
 					type="O_crew_F";
 				};
 				class Item1
@@ -11053,7 +22190,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2381.1594,5.0014391,1301.3689};
+						position[]={2381.1589,5.0014391,1301.369};
 					};
 					side="East";
 					flags=6;
@@ -11066,7 +22203,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=380;
+					id=2899;
 					type="O_crew_F";
 				};
 			};
@@ -11086,8 +22223,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=379;
-						item1=25;
+						item0=2898;
+						item1=2576;
 						class CustomData
 						{
 							role=2;
@@ -11097,8 +22234,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=380;
-						item1=25;
+						item0=2899;
+						item1=2576;
 						class CustomData
 						{
 							role=1;
@@ -11106,7 +22243,7 @@ class Mission
 					};
 				};
 			};
-			id=377;
+			id=2897;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -11131,7 +22268,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item176
+		class Item309
 		{
 			dataType="Group";
 			side="East";
@@ -11158,7 +22295,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=382;
+					id=2901;
 					type="O_Soldier_SL_F";
 					class CustomAttributes
 					{
@@ -11203,7 +22340,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=383;
+					id=2902;
 					type="O_medic_F";
 					class CustomAttributes
 					{
@@ -11234,7 +22371,7 @@ class Mission
 			{
 				name="GrpCSAT_ASL";
 			};
-			id=381;
+			id=2900;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -11259,7 +22396,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item177
+		class Item310
 		{
 			dataType="Group";
 			side="East";
@@ -11286,7 +22423,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=385;
+					id=2904;
 					type="O_Soldier_TL_F";
 					class CustomAttributes
 					{
@@ -11332,7 +22469,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=386;
+					id=2905;
 					type="O_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -11378,7 +22515,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=387;
+					id=2906;
 					type="O_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -11424,7 +22561,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=388;
+					id=2907;
 					type="O_Soldier_LAT_F";
 					class CustomAttributes
 					{
@@ -11469,7 +22606,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=389;
+					id=2908;
 					type="O_Soldier_F";
 					class CustomAttributes
 					{
@@ -11514,7 +22651,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=390;
+					id=2909;
 					type="O_Soldier_F";
 					class CustomAttributes
 					{
@@ -11545,7 +22682,7 @@ class Mission
 			{
 				name="GrpCSAT_A1";
 			};
-			id=384;
+			id=2903;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -11570,7 +22707,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item178
+		class Item311
 		{
 			dataType="Group";
 			side="East";
@@ -11597,7 +22734,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=392;
+					id=2911;
 					type="O_Soldier_TL_F";
 					class CustomAttributes
 					{
@@ -11643,7 +22780,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=393;
+					id=2912;
 					type="O_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -11689,7 +22826,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=394;
+					id=2913;
 					type="O_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -11735,7 +22872,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=395;
+					id=2914;
 					type="O_Soldier_LAT_F";
 					class CustomAttributes
 					{
@@ -11780,7 +22917,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=396;
+					id=2915;
 					type="O_Soldier_F";
 					class CustomAttributes
 					{
@@ -11825,7 +22962,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=397;
+					id=2916;
 					type="O_Soldier_F";
 					class CustomAttributes
 					{
@@ -11856,7 +22993,7 @@ class Mission
 			{
 				name="GrpCSAT_A2";
 			};
-			id=391;
+			id=2910;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -11881,7 +23018,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item179
+		class Item312
 		{
 			dataType="Group";
 			side="East";
@@ -11893,7 +23030,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2423.8577,5.0014391,1301.1443};
+						position[]={2423.8579,5.0014391,1301.144};
 					};
 					side="East";
 					flags=4;
@@ -11907,7 +23044,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=400;
+					id=2918;
 					type="O_crew_F";
 				};
 				class Item1
@@ -11915,7 +23052,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2423.8577,5.0014391,1301.1443};
+						position[]={2423.8579,5.0014391,1301.144};
 					};
 					side="East";
 					flags=6;
@@ -11928,7 +23065,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=401;
+					id=2919;
 					type="O_crew_F";
 				};
 			};
@@ -11948,8 +23085,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=400;
-						item1=26;
+						item0=2918;
+						item1=2577;
 						class CustomData
 						{
 							role=2;
@@ -11959,8 +23096,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=401;
-						item1=26;
+						item0=2919;
+						item1=2577;
 						class CustomData
 						{
 							role=1;
@@ -11968,7 +23105,7 @@ class Mission
 					};
 				};
 			};
-			id=398;
+			id=2917;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -11993,7 +23130,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item180
+		class Item313
 		{
 			dataType="Group";
 			side="East";
@@ -12020,11 +23157,30 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=403;
+					id=2921;
 					type="O_Soldier_SL_F";
 					class CustomAttributes
 					{
 						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male01PER";
+								};
+							};
+						};
+						class Attribute1
 						{
 							property="pitch";
 							expression="_this setpitch _value;";
@@ -12043,7 +23199,7 @@ class Mission
 								};
 							};
 						};
-						nAttributes=1;
+						nAttributes=2;
 					};
 				};
 				class Item1
@@ -12065,11 +23221,30 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=404;
+					id=2922;
 					type="O_medic_F";
 					class CustomAttributes
 					{
 						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male01PER";
+								};
+							};
+						};
+						class Attribute1
 						{
 							property="pitch";
 							expression="_this setpitch _value;";
@@ -12088,7 +23263,7 @@ class Mission
 								};
 							};
 						};
-						nAttributes=1;
+						nAttributes=2;
 					};
 				};
 			};
@@ -12096,7 +23271,7 @@ class Mission
 			{
 				name="GrpCSAT_BSL";
 			};
-			id=402;
+			id=2920;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -12121,7 +23296,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item181
+		class Item314
 		{
 			dataType="Group";
 			side="East";
@@ -12148,7 +23323,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=406;
+					id=2924;
 					type="O_Soldier_TL_F";
 					class CustomAttributes
 					{
@@ -12194,7 +23369,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=407;
+					id=2925;
 					type="O_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -12240,7 +23415,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=408;
+					id=2926;
 					type="O_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -12286,7 +23461,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=409;
+					id=2927;
 					type="O_Soldier_LAT_F";
 					class CustomAttributes
 					{
@@ -12331,7 +23506,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=410;
+					id=2928;
 					type="O_Soldier_F";
 					class CustomAttributes
 					{
@@ -12376,7 +23551,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=411;
+					id=2929;
 					type="O_Soldier_F";
 					class CustomAttributes
 					{
@@ -12407,7 +23582,7 @@ class Mission
 			{
 				name="GrpCSAT_B1";
 			};
-			id=405;
+			id=2923;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -12432,7 +23607,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item182
+		class Item315
 		{
 			dataType="Group";
 			side="East";
@@ -12459,7 +23634,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=413;
+					id=2931;
 					type="O_Soldier_TL_F";
 					class CustomAttributes
 					{
@@ -12505,7 +23680,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=414;
+					id=2932;
 					type="O_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -12551,7 +23726,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=415;
+					id=2933;
 					type="O_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -12597,7 +23772,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=416;
+					id=2934;
 					type="O_Soldier_LAT_F";
 					class CustomAttributes
 					{
@@ -12642,7 +23817,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=417;
+					id=2935;
 					type="O_Soldier_F";
 					class CustomAttributes
 					{
@@ -12687,7 +23862,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=418;
+					id=2936;
 					type="O_Soldier_F";
 					class CustomAttributes
 					{
@@ -12718,7 +23893,7 @@ class Mission
 			{
 				name="GrpCSAT_B2";
 			};
-			id=412;
+			id=2930;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -12743,7 +23918,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item183
+		class Item316
 		{
 			dataType="Group";
 			side="East";
@@ -12755,7 +23930,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2475.9973,5.0014391,1300.3562};
+						position[]={2475.9971,5.0014391,1300.3561};
 					};
 					side="East";
 					flags=4;
@@ -12769,7 +23944,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=421;
+					id=2938;
 					type="O_crew_F";
 					class CustomAttributes
 					{
@@ -12800,7 +23975,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2475.9973,5.0014391,1300.3562};
+						position[]={2475.9971,5.0014391,1300.3561};
 					};
 					side="East";
 					flags=6;
@@ -12813,7 +23988,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=422;
+					id=2939;
 					type="O_crew_F";
 				};
 			};
@@ -12833,8 +24008,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=421;
-						item1=27;
+						item0=2938;
+						item1=2578;
 						class CustomData
 						{
 							role=2;
@@ -12844,8 +24019,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=422;
-						item1=27;
+						item0=2939;
+						item1=2578;
 						class CustomData
 						{
 							role=1;
@@ -12853,7 +24028,7 @@ class Mission
 					};
 				};
 			};
-			id=419;
+			id=2937;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -12878,7 +24053,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item184
+		class Item317
 		{
 			dataType="Group";
 			side="East";
@@ -12905,11 +24080,30 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=424;
+					id=2941;
 					type="O_Soldier_SL_F";
 					class CustomAttributes
 					{
 						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male01PER";
+								};
+							};
+						};
+						class Attribute1
 						{
 							property="pitch";
 							expression="_this setpitch _value;";
@@ -12928,7 +24122,7 @@ class Mission
 								};
 							};
 						};
-						nAttributes=1;
+						nAttributes=2;
 					};
 				};
 				class Item1
@@ -12950,11 +24144,30 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=425;
+					id=2942;
 					type="O_medic_F";
 					class CustomAttributes
 					{
 						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male01PER";
+								};
+							};
+						};
+						class Attribute1
 						{
 							property="pitch";
 							expression="_this setpitch _value;";
@@ -12973,7 +24186,7 @@ class Mission
 								};
 							};
 						};
-						nAttributes=1;
+						nAttributes=2;
 					};
 				};
 			};
@@ -12981,7 +24194,7 @@ class Mission
 			{
 				name="GrpCSAT_CSL";
 			};
-			id=423;
+			id=2940;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -13006,7 +24219,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item185
+		class Item318
 		{
 			dataType="Group";
 			side="East";
@@ -13033,7 +24246,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=427;
+					id=2944;
 					type="O_Soldier_TL_F";
 					class CustomAttributes
 					{
@@ -13079,7 +24292,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=428;
+					id=2945;
 					type="O_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -13125,7 +24338,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=429;
+					id=2946;
 					type="O_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -13171,7 +24384,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=430;
+					id=2947;
 					type="O_Soldier_LAT_F";
 					class CustomAttributes
 					{
@@ -13216,7 +24429,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=431;
+					id=2948;
 					type="O_Soldier_F";
 					class CustomAttributes
 					{
@@ -13261,7 +24474,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=432;
+					id=2949;
 					type="O_Soldier_F";
 					class CustomAttributes
 					{
@@ -13292,7 +24505,7 @@ class Mission
 			{
 				name="GrpCSAT_C1";
 			};
-			id=426;
+			id=2943;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -13317,7 +24530,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item186
+		class Item319
 		{
 			dataType="Group";
 			side="East";
@@ -13344,7 +24557,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=434;
+					id=2951;
 					type="O_Soldier_TL_F";
 					class CustomAttributes
 					{
@@ -13390,7 +24603,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=435;
+					id=2952;
 					type="O_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -13436,7 +24649,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=436;
+					id=2953;
 					type="O_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -13482,7 +24695,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=437;
+					id=2954;
 					type="O_Soldier_LAT_F";
 					class CustomAttributes
 					{
@@ -13527,7 +24740,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=438;
+					id=2955;
 					type="O_Soldier_F";
 					class CustomAttributes
 					{
@@ -13572,7 +24785,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=439;
+					id=2956;
 					type="O_Soldier_F";
 					class CustomAttributes
 					{
@@ -13603,7 +24816,7 @@ class Mission
 			{
 				name="GrpCSAT_C2";
 			};
-			id=433;
+			id=2950;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -13628,7 +24841,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item187
+		class Item320
 		{
 			dataType="Group";
 			side="East";
@@ -13640,7 +24853,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2529.1165,5.0014391,1300.1658};
+						position[]={2529.116,5.0014391,1300.166};
 					};
 					side="East";
 					flags=4;
@@ -13654,7 +24867,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=442;
+					id=2958;
 					type="O_crew_F";
 				};
 				class Item1
@@ -13662,7 +24875,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2529.1165,5.0014391,1300.1658};
+						position[]={2529.116,5.0014391,1300.166};
 					};
 					side="East";
 					flags=6;
@@ -13675,7 +24888,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=443;
+					id=2959;
 					type="O_crew_F";
 				};
 			};
@@ -13695,8 +24908,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=442;
-						item1=28;
+						item0=2958;
+						item1=2579;
 						class CustomData
 						{
 							role=2;
@@ -13706,8 +24919,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=443;
-						item1=28;
+						item0=2959;
+						item1=2579;
 						class CustomData
 						{
 							role=1;
@@ -13715,7 +24928,7 @@ class Mission
 					};
 				};
 			};
-			id=440;
+			id=2957;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -13740,7 +24953,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item188
+		class Item321
 		{
 			dataType="Group";
 			side="East";
@@ -13767,7 +24980,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=445;
+					id=2961;
 					type="O_Soldier_TL_F";
 					class CustomAttributes
 					{
@@ -13812,7 +25025,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=446;
+					id=2962;
 					type="O_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -13858,7 +25071,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1229;
+					id=2963;
 					type="O_Soldier_AAR_F";
 				};
 			};
@@ -13866,7 +25079,7 @@ class Mission
 			{
 				name="GrpCSAT_MMG1";
 			};
-			id=444;
+			id=2960;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -13891,7 +25104,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item189
+		class Item322
 		{
 			dataType="Group";
 			side="East";
@@ -13918,7 +25131,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=448;
+					id=2965;
 					type="O_Soldier_TL_F";
 					class CustomAttributes
 					{
@@ -13963,7 +25176,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=449;
+					id=2966;
 					type="O_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -14009,7 +25222,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1230;
+					id=2967;
 					type="O_Soldier_AAR_F";
 				};
 			};
@@ -14017,7 +25230,7 @@ class Mission
 			{
 				name="GrpCSAT_MMG2";
 			};
-			id=447;
+			id=2964;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -14042,7 +25255,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item190
+		class Item323
 		{
 			dataType="Group";
 			side="East";
@@ -14068,7 +25281,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=451;
+					id=2969;
 					type="O_Soldier_TL_F";
 					class CustomAttributes
 					{
@@ -14112,7 +25325,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=452;
+					id=2970;
 					type="O_Soldier_AT_F";
 					class CustomAttributes
 					{
@@ -14157,7 +25370,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1231;
+					id=2971;
 					type="O_Soldier_AAT_F";
 				};
 			};
@@ -14165,7 +25378,7 @@ class Mission
 			{
 				name="GrpCSAT_MAT1";
 			};
-			id=450;
+			id=2968;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -14190,7 +25403,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item191
+		class Item324
 		{
 			dataType="Group";
 			side="East";
@@ -14216,7 +25429,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=454;
+					id=2973;
 					type="O_Soldier_TL_F";
 					class CustomAttributes
 					{
@@ -14260,7 +25473,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=455;
+					id=2974;
 					type="O_Soldier_AT_F";
 					class CustomAttributes
 					{
@@ -14305,7 +25518,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1232;
+					id=2975;
 					type="O_Soldier_AAT_F";
 				};
 			};
@@ -14313,7 +25526,7 @@ class Mission
 			{
 				name="GrpCSAT_MAT2";
 			};
-			id=453;
+			id=2972;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -14338,7 +25551,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item192
+		class Item325
 		{
 			dataType="Group";
 			side="East";
@@ -14364,7 +25577,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=457;
+					id=2977;
 					type="O_Soldier_TL_F";
 					class CustomAttributes
 					{
@@ -14408,7 +25621,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=458;
+					id=2978;
 					type="O_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -14439,7 +25652,7 @@ class Mission
 			{
 				name="GrpCSAT_HMG1";
 			};
-			id=456;
+			id=2976;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -14464,7 +25677,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item193
+		class Item326
 		{
 			dataType="Group";
 			side="East";
@@ -14490,7 +25703,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=460;
+					id=2980;
 					type="O_Soldier_TL_F";
 					class CustomAttributes
 					{
@@ -14534,7 +25747,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=461;
+					id=2981;
 					type="O_Soldier_AT_F";
 					class CustomAttributes
 					{
@@ -14579,7 +25792,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1233;
+					id=2982;
 					type="O_Soldier_AAT_F";
 				};
 			};
@@ -14587,7 +25800,7 @@ class Mission
 			{
 				name="GrpCSAT_HAT1";
 			};
-			id=459;
+			id=2979;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -14612,7 +25825,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item194
+		class Item327
 		{
 			dataType="Group";
 			side="East";
@@ -14638,7 +25851,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=463;
+					id=2984;
 					type="O_support_AMort_F";
 					class CustomAttributes
 					{
@@ -14682,7 +25895,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=464;
+					id=2985;
 					type="O_support_Mort_F";
 					class CustomAttributes
 					{
@@ -14713,7 +25926,7 @@ class Mission
 			{
 				name="GrpCSAT_MTR1";
 			};
-			id=462;
+			id=2983;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -14738,7 +25951,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item195
+		class Item328
 		{
 			dataType="Group";
 			side="East";
@@ -14764,7 +25977,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=466;
+					id=2987;
 					type="O_Soldier_AAA_F";
 					class CustomAttributes
 					{
@@ -14808,7 +26021,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=467;
+					id=2988;
 					type="O_Soldier_AA_F";
 					class CustomAttributes
 					{
@@ -14853,7 +26066,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1208;
+					id=2989;
 					type="O_Soldier_AAA_F";
 				};
 			};
@@ -14861,7 +26074,7 @@ class Mission
 			{
 				name="GrpCSAT_MSAM1";
 			};
-			id=465;
+			id=2986;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -14886,7 +26099,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item196
+		class Item329
 		{
 			dataType="Group";
 			side="East";
@@ -14912,7 +26125,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=469;
+					id=2991;
 					type="O_Soldier_AAA_F";
 					class CustomAttributes
 					{
@@ -14956,7 +26169,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=470;
+					id=2992;
 					type="O_Soldier_AA_F";
 					class CustomAttributes
 					{
@@ -14987,7 +26200,7 @@ class Mission
 			{
 				name="GrpCSAT_HSAM1";
 			};
-			id=468;
+			id=2990;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -15012,7 +26225,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item197
+		class Item330
 		{
 			dataType="Group";
 			side="East";
@@ -15038,11 +26251,30 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=472;
+					id=2994;
 					type="O_spotter_F";
 					class CustomAttributes
 					{
 						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male02PER";
+								};
+							};
+						};
+						class Attribute1
 						{
 							property="pitch";
 							expression="_this setpitch _value;";
@@ -15061,7 +26293,7 @@ class Mission
 								};
 							};
 						};
-						nAttributes=1;
+						nAttributes=2;
 					};
 				};
 				class Item1
@@ -15082,11 +26314,30 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=473;
+					id=2995;
 					type="O_sniper_F";
 					class CustomAttributes
 					{
 						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male02PER";
+								};
+							};
+						};
+						class Attribute1
 						{
 							property="pitch";
 							expression="_this setpitch _value;";
@@ -15105,7 +26356,7 @@ class Mission
 								};
 							};
 						};
-						nAttributes=1;
+						nAttributes=2;
 					};
 				};
 			};
@@ -15113,7 +26364,7 @@ class Mission
 			{
 				name="GrpCSAT_ST1";
 			};
-			id=471;
+			id=2993;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -15138,7 +26389,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item198
+		class Item331
 		{
 			dataType="Group";
 			side="East";
@@ -15164,7 +26415,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=475;
+					id=2997;
 					type="O_engineer_F";
 					class CustomAttributes
 					{
@@ -15208,7 +26459,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=476;
+					id=2998;
 					type="O_engineer_F";
 					class CustomAttributes
 					{
@@ -15252,7 +26503,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=477;
+					id=2999;
 					type="O_engineer_F";
 					class CustomAttributes
 					{
@@ -15296,7 +26547,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=478;
+					id=3000;
 					type="O_engineer_F";
 					class CustomAttributes
 					{
@@ -15327,7 +26578,7 @@ class Mission
 			{
 				name="GrpCSAT_ENG1";
 			};
-			id=474;
+			id=2996;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -15352,7 +26603,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item199
+		class Item332
 		{
 			dataType="Group";
 			side="East";
@@ -15378,7 +26629,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=480;
+					id=3002;
 					type="O_diver_TL_F";
 					class CustomAttributes
 					{
@@ -15423,7 +26674,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=481;
+					id=3003;
 					type="O_diver_F";
 					class CustomAttributes
 					{
@@ -15468,7 +26719,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=482;
+					id=3004;
 					type="O_diver_F";
 					class CustomAttributes
 					{
@@ -15513,7 +26764,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=483;
+					id=3005;
 					type="O_diver_F";
 					class CustomAttributes
 					{
@@ -15544,7 +26795,7 @@ class Mission
 			{
 				name="GrpCSAT_DT1";
 			};
-			id=479;
+			id=3001;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -15569,7 +26820,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item200
+		class Item333
 		{
 			dataType="Group";
 			side="East";
@@ -15581,7 +26832,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2381.4866,5.0014391,1276.0164};
+						position[]={2381.4871,4.8214393,1276.016};
 					};
 					side="East";
 					flags=6;
@@ -15595,8 +26846,9 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=485;
+					id=3007;
 					type="O_crew_F";
+					atlOffset=-0.17999983;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -15626,7 +26878,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2381.4866,5.0014391,1276.0164};
+						position[]={2381.4871,4.8214393,1276.016};
 					};
 					side="East";
 					flags=4;
@@ -15640,15 +26892,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=486;
+					id=3008;
 					type="O_crew_F";
+					atlOffset=-0.17999983;
 				};
 				class Item2
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2381.4866,5.0014391,1276.0164};
+						position[]={2381.4871,4.8214393,1276.016};
 					};
 					side="East";
 					flags=4;
@@ -15661,8 +26914,9 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=487;
+					id=3009;
 					type="O_crew_F";
+					atlOffset=-0.17999983;
 				};
 			};
 			class Attributes
@@ -15681,8 +26935,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=485;
-						item1=77;
+						item0=3007;
+						item1=2628;
 						class CustomData
 						{
 							role=2;
@@ -15692,8 +26946,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=486;
-						item1=77;
+						item0=3008;
+						item1=2628;
 						class CustomData
 						{
 							role=2;
@@ -15703,8 +26957,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=487;
-						item1=77;
+						item0=3009;
+						item1=2628;
 						class CustomData
 						{
 							role=1;
@@ -15712,8 +26966,8 @@ class Mission
 					};
 				};
 			};
-			id=484;
-			atlOffset=-0.18001461;
+			id=3006;
+			atlOffset=-0.17999983;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -15738,7 +26992,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item201
+		class Item334
 		{
 			dataType="Group";
 			side="East";
@@ -15750,7 +27004,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2426.5959,5.0014391,1276.3611};
+						position[]={2426.5959,4.8214393,1276.3611};
 					};
 					side="East";
 					flags=6;
@@ -15764,15 +27018,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=489;
+					id=3011;
 					type="O_crew_F";
+					atlOffset=-0.17999983;
 				};
 				class Item1
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2426.5959,5.0014391,1276.3611};
+						position[]={2426.5959,4.8214393,1276.3611};
 					};
 					side="East";
 					flags=4;
@@ -15786,15 +27041,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=490;
+					id=3012;
 					type="O_crew_F";
+					atlOffset=-0.17999983;
 				};
 				class Item2
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2426.5959,5.0014391,1276.3611};
+						position[]={2426.5959,4.8214393,1276.3611};
 					};
 					side="East";
 					flags=4;
@@ -15807,8 +27063,9 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=491;
+					id=3013;
 					type="O_crew_F";
+					atlOffset=-0.17999983;
 				};
 			};
 			class Attributes
@@ -15827,8 +27084,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=489;
-						item1=78;
+						item0=3011;
+						item1=2629;
 						class CustomData
 						{
 							role=2;
@@ -15838,8 +27095,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=490;
-						item1=78;
+						item0=3012;
+						item1=2629;
 						class CustomData
 						{
 							role=2;
@@ -15849,8 +27106,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=491;
-						item1=78;
+						item0=3013;
+						item1=2629;
 						class CustomData
 						{
 							role=1;
@@ -15858,8 +27115,8 @@ class Mission
 					};
 				};
 			};
-			id=488;
-			atlOffset=-0.18001461;
+			id=3010;
+			atlOffset=-0.17999983;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -15884,7 +27141,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item202
+		class Item335
 		{
 			dataType="Group";
 			side="East";
@@ -15896,7 +27153,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2477.0383,5.0014391,1274.8718};
+						position[]={2477.0381,4.8204393,1274.875};
 					};
 					side="East";
 					flags=6;
@@ -15910,15 +27167,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=493;
+					id=3015;
 					type="O_crew_F";
+					atlOffset=-0.18099976;
 				};
 				class Item1
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2477.0383,5.0014391,1274.8718};
+						position[]={2477.0381,4.8204393,1274.875};
 					};
 					side="East";
 					flags=4;
@@ -15932,15 +27190,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=494;
+					id=3016;
 					type="O_crew_F";
+					atlOffset=-0.18099976;
 				};
 				class Item2
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2477.0383,5.0014391,1274.8718};
+						position[]={2477.0381,4.8204393,1274.875};
 					};
 					side="East";
 					flags=4;
@@ -15953,8 +27212,9 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=495;
+					id=3017;
 					type="O_crew_F";
+					atlOffset=-0.18099976;
 				};
 			};
 			class Attributes
@@ -15973,8 +27233,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=493;
-						item1=35;
+						item0=3015;
+						item1=2586;
 						class CustomData
 						{
 							role=2;
@@ -15984,8 +27244,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=494;
-						item1=35;
+						item0=3016;
+						item1=2586;
 						class CustomData
 						{
 							role=2;
@@ -15995,8 +27255,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=495;
-						item1=35;
+						item0=3017;
+						item1=2586;
 						class CustomData
 						{
 							role=1;
@@ -16004,8 +27264,8 @@ class Mission
 					};
 				};
 			};
-			id=492;
-			atlOffset=-0.18066597;
+			id=3014;
+			atlOffset=-0.18099976;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -16030,7 +27290,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item203
+		class Item336
 		{
 			dataType="Group";
 			side="East";
@@ -16042,7 +27302,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2379.1594,5.0014391,1254.6062};
+						position[]={2379.1589,5.0014391,1254.6061};
 					};
 					side="East";
 					flags=6;
@@ -16056,7 +27316,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=497;
+					id=3019;
 					type="O_helipilot_F";
 				};
 				class Item1
@@ -16064,7 +27324,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2379.1594,5.0014391,1254.6062};
+						position[]={2379.1589,5.0014391,1254.6061};
 					};
 					side="East";
 					flags=4;
@@ -16078,7 +27338,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=498;
+					id=3020;
 					type="O_helipilot_F";
 				};
 				class Item2
@@ -16086,7 +27346,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2379.1594,5.0014391,1254.6062};
+						position[]={2379.1589,5.0014391,1254.6061};
 					};
 					side="East";
 					flags=4;
@@ -16100,7 +27360,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=499;
+					id=3021;
 					type="O_helicrew_F";
 					class CustomAttributes
 					{
@@ -16143,8 +27403,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=497;
-						item1=1;
+						item0=3019;
+						item1=2552;
 						class CustomData
 						{
 							role=1;
@@ -16153,8 +27413,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=498;
-						item1=1;
+						item0=3020;
+						item1=2552;
 						class CustomData
 						{
 							role=2;
@@ -16164,8 +27424,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=499;
-						item1=1;
+						item0=3021;
+						item1=2552;
 						class CustomData
 						{
 							role=2;
@@ -16174,7 +27434,7 @@ class Mission
 					};
 				};
 			};
-			id=496;
+			id=3018;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -16199,7 +27459,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item204
+		class Item337
 		{
 			dataType="Group";
 			side="East";
@@ -16211,7 +27471,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2380.8411,5.0014391,1224.6824};
+						position[]={2380.8411,5.0014391,1224.682};
 					};
 					side="East";
 					flags=6;
@@ -16225,7 +27485,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=501;
+					id=3023;
 					type="O_helipilot_F";
 				};
 				class Item1
@@ -16233,7 +27493,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2380.8411,5.0014391,1224.6824};
+						position[]={2380.8411,5.0014391,1224.682};
 					};
 					side="East";
 					flags=4;
@@ -16247,7 +27507,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=502;
+					id=3024;
 					type="O_helipilot_F";
 				};
 				class Item2
@@ -16255,7 +27515,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2380.8411,5.0014391,1224.6824};
+						position[]={2380.8411,5.0014391,1224.682};
 					};
 					side="East";
 					flags=4;
@@ -16269,7 +27529,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=503;
+					id=3025;
 					type="O_helicrew_F";
 					class CustomAttributes
 					{
@@ -16312,8 +27572,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=501;
-						item1=18;
+						item0=3023;
+						item1=2569;
 						class CustomData
 						{
 							role=1;
@@ -16322,8 +27582,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=502;
-						item1=18;
+						item0=3024;
+						item1=2569;
 						class CustomData
 						{
 							role=2;
@@ -16333,8 +27593,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=503;
-						item1=18;
+						item0=3025;
+						item1=2569;
 						class CustomData
 						{
 							role=2;
@@ -16343,7 +27603,7 @@ class Mission
 					};
 				};
 			};
-			id=500;
+			id=3022;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -16368,7 +27628,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item205
+		class Item338
 		{
 			dataType="Group";
 			side="East";
@@ -16380,7 +27640,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2429.5403,5.0014391,1253.7297};
+						position[]={2429.54,5.0014391,1253.7301};
 					};
 					side="East";
 					flags=6;
@@ -16394,7 +27654,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=505;
+					id=3027;
 					type="O_helipilot_F";
 				};
 				class Item1
@@ -16402,7 +27662,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2429.5403,5.0014391,1253.7297};
+						position[]={2429.54,5.0014391,1253.7301};
 					};
 					side="East";
 					flags=4;
@@ -16416,7 +27676,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=506;
+					id=3028;
 					type="O_helipilot_F";
 				};
 			};
@@ -16436,8 +27696,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=505;
-						item1=19;
+						item0=3027;
+						item1=2570;
 						class CustomData
 						{
 							role=1;
@@ -16446,8 +27706,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=506;
-						item1=19;
+						item0=3028;
+						item1=2570;
 						class CustomData
 						{
 							role=2;
@@ -16456,7 +27716,7 @@ class Mission
 					};
 				};
 			};
-			id=504;
+			id=3026;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -16481,7 +27741,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item206
+		class Item339
 		{
 			dataType="Group";
 			side="East";
@@ -16493,7 +27753,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2426.9114,5.0014391,1224.01};
+						position[]={2426.9109,5.0014391,1224.01};
 					};
 					side="East";
 					flags=6;
@@ -16507,7 +27767,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=508;
+					id=3030;
 					type="O_helipilot_F";
 				};
 				class Item1
@@ -16515,7 +27775,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2426.9114,5.0014391,1224.01};
+						position[]={2426.9109,5.0014391,1224.01};
 					};
 					side="East";
 					flags=4;
@@ -16529,7 +27789,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=509;
+					id=3031;
 					type="O_helipilot_F";
 				};
 			};
@@ -16549,8 +27809,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=508;
-						item1=20;
+						item0=3030;
+						item1=2571;
 						class CustomData
 						{
 							role=1;
@@ -16559,8 +27819,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=509;
-						item1=20;
+						item0=3031;
+						item1=2571;
 						class CustomData
 						{
 							role=2;
@@ -16569,7 +27829,7 @@ class Mission
 					};
 				};
 			};
-			id=507;
+			id=3029;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -16594,7 +27854,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item207
+		class Item340
 		{
 			dataType="Group";
 			side="East";
@@ -16606,7 +27866,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2480.3333,5.0014391,1253.3899};
+						position[]={2480.333,5.0014391,1253.39};
 					};
 					side="East";
 					flags=6;
@@ -16620,7 +27880,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=511;
+					id=3033;
 					type="O_helipilot_F";
 				};
 				class Item1
@@ -16628,7 +27888,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2480.3333,5.0014391,1253.3899};
+						position[]={2480.333,5.0014391,1253.39};
 					};
 					side="East";
 					flags=4;
@@ -16642,7 +27902,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=512;
+					id=3034;
 					type="O_helipilot_F";
 				};
 			};
@@ -16662,8 +27922,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=511;
-						item1=21;
+						item0=3033;
+						item1=2572;
 						class CustomData
 						{
 							role=1;
@@ -16672,8 +27932,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=512;
-						item1=21;
+						item0=3034;
+						item1=2572;
 						class CustomData
 						{
 							role=2;
@@ -16682,7 +27942,7 @@ class Mission
 					};
 				};
 			};
-			id=510;
+			id=3032;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -16707,7 +27967,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item208
+		class Item341
 		{
 			dataType="Group";
 			side="East";
@@ -16719,7 +27979,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2477.6995,5.0014391,1223.6653};
+						position[]={2477.699,5.0014391,1223.665};
 					};
 					side="East";
 					flags=6;
@@ -16733,7 +27993,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=514;
+					id=3036;
 					type="O_helipilot_F";
 				};
 				class Item1
@@ -16741,7 +28001,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2477.6995,5.0014391,1223.6653};
+						position[]={2477.699,5.0014391,1223.665};
 					};
 					side="East";
 					flags=4;
@@ -16755,7 +28015,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=515;
+					id=3037;
 					type="O_helipilot_F";
 				};
 			};
@@ -16775,8 +28035,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=514;
-						item1=22;
+						item0=3036;
+						item1=2573;
 						class CustomData
 						{
 							role=1;
@@ -16785,8 +28045,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=515;
-						item1=22;
+						item0=3037;
+						item1=2573;
 						class CustomData
 						{
 							role=2;
@@ -16795,7 +28055,7 @@ class Mission
 					};
 				};
 			};
-			id=513;
+			id=3035;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -16820,7 +28080,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item209
+		class Item342
 		{
 			dataType="Group";
 			side="East";
@@ -16832,7 +28092,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2534.553,5.0014391,1253.7854};
+						position[]={2534.553,5.0014391,1253.785};
 					};
 					side="East";
 					flags=6;
@@ -16846,7 +28106,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=517;
+					id=3039;
 					type="O_helipilot_F";
 				};
 				class Item1
@@ -16854,7 +28114,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2534.553,5.0014391,1253.7854};
+						position[]={2534.553,5.0014391,1253.785};
 					};
 					side="East";
 					flags=4;
@@ -16868,7 +28128,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=518;
+					id=3040;
 					type="O_helipilot_F";
 				};
 			};
@@ -16888,8 +28148,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=517;
-						item1=23;
+						item0=3039;
+						item1=2574;
 						class CustomData
 						{
 							role=1;
@@ -16898,8 +28158,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=518;
-						item1=23;
+						item0=3040;
+						item1=2574;
 						class CustomData
 						{
 							role=2;
@@ -16908,7 +28168,7 @@ class Mission
 					};
 				};
 			};
-			id=516;
+			id=3038;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -16933,7 +28193,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item210
+		class Item343
 		{
 			dataType="Group";
 			side="East";
@@ -16945,7 +28205,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2531.9211,5.0014391,1224.0647};
+						position[]={2531.9209,5.0014391,1224.0651};
 					};
 					side="East";
 					flags=6;
@@ -16959,7 +28219,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=520;
+					id=3042;
 					type="O_helipilot_F";
 				};
 				class Item1
@@ -16967,7 +28227,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2531.9211,5.0014391,1224.0647};
+						position[]={2531.9209,5.0014391,1224.0651};
 					};
 					side="East";
 					flags=4;
@@ -16981,7 +28241,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=521;
+					id=3043;
 					type="O_helipilot_F";
 				};
 			};
@@ -17001,8 +28261,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=520;
-						item1=24;
+						item0=3042;
+						item1=2575;
 						class CustomData
 						{
 							role=1;
@@ -17011,8 +28271,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=521;
-						item1=24;
+						item0=3043;
+						item1=2575;
 						class CustomData
 						{
 							role=2;
@@ -17021,7 +28281,7 @@ class Mission
 					};
 				};
 			};
-			id=519;
+			id=3041;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -17046,7 +28306,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item211
+		class Item344
 		{
 			dataType="Group";
 			side="East";
@@ -17058,7 +28318,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2382.634,5.0014391,1193.7566};
+						position[]={2382.634,5.0014391,1193.7571};
 					};
 					side="East";
 					flags=6;
@@ -17072,7 +28332,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=523;
+					id=3045;
 					type="O_helipilot_F";
 					class CustomAttributes
 					{
@@ -17103,7 +28363,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2382.634,5.0014391,1193.7566};
+						position[]={2382.634,5.0014391,1193.7571};
 					};
 					side="East";
 					flags=4;
@@ -17117,7 +28377,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=524;
+					id=3046;
 					type="O_helipilot_F";
 				};
 			};
@@ -17137,8 +28397,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=523;
-						item1=29;
+						item0=3045;
+						item1=2580;
 						class CustomData
 						{
 							role=1;
@@ -17147,8 +28407,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=524;
-						item1=29;
+						item0=3046;
+						item1=2580;
 						class CustomData
 						{
 							role=2;
@@ -17157,7 +28417,7 @@ class Mission
 					};
 				};
 			};
-			id=522;
+			id=3044;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -17182,7 +28442,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item212
+		class Item345
 		{
 			dataType="Group";
 			side="Independent";
@@ -17194,7 +28454,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1409.1733,5.0014391,765.03137};
+						position[]={1381.9424,5.0014391,1365.5823};
 					};
 					side="Independent";
 					flags=6;
@@ -17208,7 +28468,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=531;
+					id=3048;
 					type="I_officer_F";
 				};
 				class Item1
@@ -17216,7 +28476,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1414.1733,5.0014391,763.38098};
+						position[]={1386.9424,5.0014391,1363.9319};
 					};
 					side="Independent";
 					flags=4;
@@ -17230,7 +28490,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=532;
+					id=3049;
 					type="I_officer_F";
 				};
 				class Item2
@@ -17238,7 +28498,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1404.1733,5.0014391,763.38098};
+						position[]={1376.9424,5.0014391,1363.9319};
 					};
 					side="Independent";
 					flags=4;
@@ -17251,7 +28511,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=533;
+					id=3050;
 					type="I_soldier_UAV_F";
 				};
 				class Item3
@@ -17259,7 +28519,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1419.1733,5.0014391,760.64172};
+						position[]={1391.9424,5.0014391,1361.1926};
 					};
 					side="Independent";
 					flags=4;
@@ -17272,7 +28532,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=534;
+					id=3051;
 					type="I_medic_F";
 				};
 			};
@@ -17280,7 +28540,7 @@ class Mission
 			{
 				name="GrpAAF_CO";
 			};
-			id=530;
+			id=3047;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -17305,7 +28565,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item213
+		class Item346
 		{
 			dataType="Group";
 			side="Independent";
@@ -17317,7 +28577,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1409.4722,5.0014391,735.45129};
+						position[]={1382.2412,5.0014391,1336.0022};
 					};
 					side="Independent";
 					flags=6;
@@ -17331,7 +28591,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=536;
+					id=3053;
 					type="I_officer_F";
 				};
 				class Item1
@@ -17339,7 +28599,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1414.4722,5.0014391,733.8009};
+						position[]={1387.2412,5.0014391,1334.3518};
 					};
 					side="Independent";
 					flags=4;
@@ -17353,7 +28613,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=537;
+					id=3054;
 					type="I_officer_F";
 				};
 				class Item2
@@ -17361,7 +28621,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1404.4722,5.0014391,733.8009};
+						position[]={1377.2412,5.0014391,1334.3518};
 					};
 					side="Independent";
 					flags=4;
@@ -17374,7 +28634,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=538;
+					id=3055;
 					type="I_soldier_UAV_F";
 				};
 				class Item3
@@ -17382,7 +28642,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1419.4722,5.0014391,731.06165};
+						position[]={1392.2412,5.0014391,1331.6125};
 					};
 					side="Independent";
 					flags=4;
@@ -17395,7 +28655,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=539;
+					id=3056;
 					type="I_medic_F";
 				};
 			};
@@ -17404,7 +28664,7 @@ class Mission
 				name="GrpAAF_DC";
 				init="DC";
 			};
-			id=535;
+			id=3052;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -17429,7 +28689,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item214
+		class Item347
 		{
 			dataType="Group";
 			side="Independent";
@@ -17441,7 +28701,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1408.4087,5.0014391,675.29236};
+						position[]={1381.178,5.0014391,1275.843};
 					};
 					side="Independent";
 					flags=6;
@@ -17455,7 +28715,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=541;
+					id=3058;
 					type="I_crew_F";
 				};
 				class Item1
@@ -17463,7 +28723,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1408.4087,5.0014391,675.29236};
+						position[]={1381.178,5.0014391,1275.843};
 					};
 					side="Independent";
 					flags=4;
@@ -17477,7 +28737,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=542;
+					id=3059;
 					type="I_crew_F";
 				};
 				class Item2
@@ -17485,7 +28745,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1408.4087,5.0014391,675.29236};
+						position[]={1381.178,5.0014391,1275.843};
 					};
 					side="Independent";
 					flags=4;
@@ -17498,7 +28758,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=543;
+					id=3060;
 					type="I_crew_F";
 				};
 			};
@@ -17518,8 +28778,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=541;
-						item1=31;
+						item0=3058;
+						item1=2582;
 						class CustomData
 						{
 							role=2;
@@ -17529,8 +28789,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=542;
-						item1=31;
+						item0=3059;
+						item1=2582;
 						class CustomData
 						{
 							role=2;
@@ -17540,8 +28800,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=543;
-						item1=31;
+						item0=3060;
+						item1=2582;
 						class CustomData
 						{
 							role=1;
@@ -17549,7 +28809,7 @@ class Mission
 					};
 				};
 			};
-			id=540;
+			id=3057;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -17574,7 +28834,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item215
+		class Item348
 		{
 			dataType="Group";
 			side="Independent";
@@ -17586,7 +28846,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1450.0649,5.0014391,763.6593};
+						position[]={1422.834,5.0014391,1364.2102};
 					};
 					side="Independent";
 					flags=6;
@@ -17600,7 +28860,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=545;
+					id=3062;
 					type="I_Soldier_SL_F";
 				};
 				class Item1
@@ -17608,7 +28868,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1455.0649,5.0014391,762.00891};
+						position[]={1427.834,5.0014391,1362.5598};
 					};
 					side="Independent";
 					flags=4;
@@ -17621,7 +28881,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=546;
+					id=3063;
 					type="I_medic_F";
 				};
 			};
@@ -17629,7 +28889,7 @@ class Mission
 			{
 				name="GrpAAF_ASL";
 			};
-			id=544;
+			id=3061;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -17654,7 +28914,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item216
+		class Item349
 		{
 			dataType="Group";
 			side="Independent";
@@ -17666,7 +28926,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1451.0005,5.0014391,736.37317};
+						position[]={1423.7695,5.0014391,1336.9241};
 					};
 					side="Independent";
 					flags=6;
@@ -17680,7 +28940,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=548;
+					id=3065;
 					type="I_Soldier_TL_F";
 				};
 				class Item1
@@ -17688,7 +28948,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1456.0005,5.0014391,734.72278};
+						position[]={1428.7695,5.0014391,1335.2737};
 					};
 					side="Independent";
 					flags=4;
@@ -17702,7 +28962,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=549;
+					id=3066;
 					type="I_Soldier_AR_F";
 				};
 				class Item2
@@ -17710,7 +28970,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1446.0005,5.0014391,734.72278};
+						position[]={1418.7695,5.0014391,1335.2737};
 					};
 					side="Independent";
 					flags=4;
@@ -17724,7 +28984,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=550;
+					id=3067;
 					type="I_Soldier_AR_F";
 				};
 				class Item3
@@ -17732,7 +28992,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1461.0005,5.0014391,731.9845};
+						position[]={1433.7695,5.0014391,1332.5354};
 					};
 					side="Independent";
 					flags=4;
@@ -17746,7 +29006,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=551;
+					id=3068;
 					type="I_Soldier_LAT_F";
 				};
 				class Item4
@@ -17754,7 +29014,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1441.0005,5.0014391,731.9845};
+						position[]={1413.7695,5.0014391,1332.5354};
 					};
 					side="Independent";
 					flags=4;
@@ -17767,7 +29027,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=552;
+					id=3069;
 					type="I_soldier_F";
 				};
 				class Item5
@@ -17775,7 +29035,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1466.0005,5.0014391,727.43665};
+						position[]={1438.7695,5.0014391,1327.9875};
 					};
 					side="Independent";
 					flags=4;
@@ -17788,7 +29048,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=553;
+					id=3070;
 					type="I_soldier_F";
 				};
 			};
@@ -17796,7 +29056,7 @@ class Mission
 			{
 				name="GrpAAF_A1";
 			};
-			id=547;
+			id=3064;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -17821,7 +29081,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item217
+		class Item350
 		{
 			dataType="Group";
 			side="Independent";
@@ -17833,7 +29093,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1450.7368,5.0014391,710.55286};
+						position[]={1423.5059,5.0014391,1311.1038};
 					};
 					side="Independent";
 					flags=6;
@@ -17847,7 +29107,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=555;
+					id=3072;
 					type="I_Soldier_TL_F";
 				};
 				class Item1
@@ -17855,7 +29115,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1455.7368,5.0014391,708.90247};
+						position[]={1428.5059,5.0014391,1309.4534};
 					};
 					side="Independent";
 					flags=4;
@@ -17869,7 +29129,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=556;
+					id=3073;
 					type="I_Soldier_AR_F";
 				};
 				class Item2
@@ -17877,7 +29137,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1445.7368,5.0014391,708.90247};
+						position[]={1418.5059,5.0014391,1309.4534};
 					};
 					side="Independent";
 					flags=4;
@@ -17891,7 +29151,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=557;
+					id=3074;
 					type="I_Soldier_AR_F";
 				};
 				class Item3
@@ -17899,7 +29159,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1460.7368,5.0014391,706.16321};
+						position[]={1433.5059,5.0014391,1306.7141};
 					};
 					side="Independent";
 					flags=4;
@@ -17913,7 +29173,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=558;
+					id=3075;
 					type="I_Soldier_LAT_F";
 				};
 				class Item4
@@ -17921,7 +29181,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1440.7368,5.0014391,706.16321};
+						position[]={1413.5059,5.0014391,1306.7141};
 					};
 					side="Independent";
 					flags=4;
@@ -17934,7 +29194,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=559;
+					id=3076;
 					type="I_soldier_F";
 				};
 				class Item5
@@ -17942,7 +29202,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1465.7368,5.0014391,701.61731};
+						position[]={1438.5059,5.0014391,1302.1682};
 					};
 					side="Independent";
 					flags=4;
@@ -17955,7 +29215,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=560;
+					id=3077;
 					type="I_soldier_F";
 				};
 			};
@@ -17963,7 +29223,7 @@ class Mission
 			{
 				name="GrpAAF_A2";
 			};
-			id=554;
+			id=3071;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -17988,7 +29248,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item218
+		class Item351
 		{
 			dataType="Group";
 			side="Independent";
@@ -18000,7 +29260,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1453.1089,5.0014391,674.15173};
+						position[]={1425.8781,5.0014391,1274.703};
 					};
 					side="Independent";
 					flags=6;
@@ -18014,7 +29274,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=562;
+					id=3079;
 					type="I_crew_F";
 				};
 				class Item1
@@ -18022,7 +29282,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1453.1089,5.0014391,674.15173};
+						position[]={1425.8781,5.0014391,1274.703};
 					};
 					side="Independent";
 					flags=4;
@@ -18036,7 +29296,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=563;
+					id=3080;
 					type="I_crew_F";
 				};
 				class Item2
@@ -18044,7 +29304,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1453.1089,5.0014391,674.15173};
+						position[]={1425.8781,5.0014391,1274.703};
 					};
 					side="Independent";
 					flags=4;
@@ -18057,7 +29317,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=564;
+					id=3081;
 					type="I_crew_F";
 				};
 			};
@@ -18077,8 +29337,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=562;
-						item1=32;
+						item0=3079;
+						item1=2583;
 						class CustomData
 						{
 							role=2;
@@ -18088,8 +29348,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=563;
-						item1=32;
+						item0=3080;
+						item1=2583;
 						class CustomData
 						{
 							role=2;
@@ -18099,8 +29359,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=564;
-						item1=32;
+						item0=3081;
+						item1=2583;
 						class CustomData
 						{
 							role=1;
@@ -18108,7 +29368,7 @@ class Mission
 					};
 				};
 			};
-			id=561;
+			id=3078;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -18133,7 +29393,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item219
+		class Item352
 		{
 			dataType="Group";
 			side="Independent";
@@ -18145,7 +29405,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1493.1655,5.0014391,763.75696};
+						position[]={1465.9346,5.0014391,1364.3079};
 					};
 					side="Independent";
 					flags=6;
@@ -18159,7 +29419,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=566;
+					id=3083;
 					type="I_Soldier_SL_F";
 				};
 				class Item1
@@ -18167,7 +29427,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1498.1655,5.0014391,762.10657};
+						position[]={1470.9346,5.0014391,1362.6575};
 					};
 					side="Independent";
 					flags=4;
@@ -18180,7 +29440,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=567;
+					id=3084;
 					type="I_medic_F";
 				};
 			};
@@ -18188,7 +29448,7 @@ class Mission
 			{
 				name="GrpAAF_BSL";
 			};
-			id=565;
+			id=3082;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -18213,7 +29473,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item220
+		class Item353
 		{
 			dataType="Group";
 			side="Independent";
@@ -18225,7 +29485,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1493.4175,5.0014391,736.32141};
+						position[]={1466.1865,5.0014391,1336.8723};
 					};
 					side="Independent";
 					flags=6;
@@ -18239,7 +29499,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=569;
+					id=3086;
 					type="I_Soldier_TL_F";
 				};
 				class Item1
@@ -18247,7 +29507,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1498.4175,5.0014391,734.67102};
+						position[]={1471.1865,5.0014391,1335.2219};
 					};
 					side="Independent";
 					flags=4;
@@ -18261,7 +29521,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=570;
+					id=3087;
 					type="I_Soldier_AR_F";
 				};
 				class Item2
@@ -18269,7 +29529,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1488.4175,5.0014391,734.67102};
+						position[]={1461.1865,5.0014391,1335.2219};
 					};
 					side="Independent";
 					flags=4;
@@ -18283,7 +29543,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=571;
+					id=3088;
 					type="I_Soldier_AR_F";
 				};
 				class Item3
@@ -18291,7 +29551,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1503.4175,5.0014391,731.93176};
+						position[]={1476.1865,5.0014391,1332.4827};
 					};
 					side="Independent";
 					flags=4;
@@ -18305,7 +29565,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=572;
+					id=3089;
 					type="I_Soldier_LAT_F";
 				};
 				class Item4
@@ -18313,7 +29573,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1483.4175,5.0014391,731.93176};
+						position[]={1456.1865,5.0014391,1332.4827};
 					};
 					side="Independent";
 					flags=4;
@@ -18326,7 +29586,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=573;
+					id=3090;
 					type="I_soldier_F";
 				};
 				class Item5
@@ -18334,7 +29594,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1508.4175,5.0014391,727.38489};
+						position[]={1481.1865,5.0014391,1327.9358};
 					};
 					side="Independent";
 					flags=4;
@@ -18347,7 +29607,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=574;
+					id=3091;
 					type="I_soldier_F";
 				};
 			};
@@ -18355,7 +29615,7 @@ class Mission
 			{
 				name="GrpAAF_B1";
 			};
-			id=568;
+			id=3085;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -18380,7 +29640,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item221
+		class Item354
 		{
 			dataType="Group";
 			side="Independent";
@@ -18392,7 +29652,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1493.1011,5.0014391,710.02844};
+						position[]={1465.8701,5.0014391,1310.5793};
 					};
 					side="Independent";
 					flags=6;
@@ -18406,7 +29666,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=576;
+					id=3093;
 					type="I_Soldier_TL_F";
 				};
 				class Item1
@@ -18414,7 +29674,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1498.1011,5.0014391,708.37903};
+						position[]={1470.8701,5.0014391,1308.9299};
 					};
 					side="Independent";
 					flags=4;
@@ -18428,7 +29688,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=577;
+					id=3094;
 					type="I_Soldier_AR_F";
 				};
 				class Item2
@@ -18436,7 +29696,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1488.1011,5.0014391,708.37903};
+						position[]={1460.8701,5.0014391,1308.9299};
 					};
 					side="Independent";
 					flags=4;
@@ -18450,7 +29710,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=578;
+					id=3095;
 					type="I_Soldier_AR_F";
 				};
 				class Item3
@@ -18458,7 +29718,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1503.1011,5.0014391,705.63879};
+						position[]={1475.8701,5.0014391,1306.1897};
 					};
 					side="Independent";
 					flags=4;
@@ -18472,7 +29732,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=579;
+					id=3096;
 					type="I_Soldier_LAT_F";
 				};
 				class Item4
@@ -18480,7 +29740,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1483.1011,5.0014391,705.63879};
+						position[]={1455.8701,5.0014391,1306.1897};
 					};
 					side="Independent";
 					flags=4;
@@ -18493,7 +29753,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=580;
+					id=3097;
 					type="I_soldier_F";
 				};
 				class Item5
@@ -18501,7 +29761,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1508.1011,5.0014391,701.09192};
+						position[]={1480.8701,5.0014391,1301.6428};
 					};
 					side="Independent";
 					flags=4;
@@ -18514,7 +29774,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=581;
+					id=3098;
 					type="I_soldier_F";
 				};
 			};
@@ -18522,7 +29782,7 @@ class Mission
 			{
 				name="GrpAAF_B2";
 			};
-			id=575;
+			id=3092;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -18547,7 +29807,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item222
+		class Item355
 		{
 			dataType="Group";
 			side="Independent";
@@ -18559,7 +29819,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1493.9253,5.0014391,674.21716};
+						position[]={1466.694,5.0014391,1274.7681};
 					};
 					side="Independent";
 					flags=6;
@@ -18573,7 +29833,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=583;
+					id=3100;
 					type="I_crew_F";
 				};
 				class Item1
@@ -18581,7 +29841,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1493.9253,5.0014391,674.21716};
+						position[]={1466.694,5.0014391,1274.7681};
 					};
 					side="Independent";
 					flags=4;
@@ -18595,7 +29855,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=584;
+					id=3101;
 					type="I_crew_F";
 				};
 				class Item2
@@ -18603,7 +29863,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1493.9253,5.0014391,674.21716};
+						position[]={1466.694,5.0014391,1274.7681};
 					};
 					side="Independent";
 					flags=4;
@@ -18616,7 +29876,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=585;
+					id=3102;
 					type="I_crew_F";
 				};
 			};
@@ -18636,8 +29896,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=583;
-						item1=33;
+						item0=3100;
+						item1=2584;
 						class CustomData
 						{
 							role=2;
@@ -18647,8 +29907,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=584;
-						item1=33;
+						item0=3101;
+						item1=2584;
 						class CustomData
 						{
 							role=2;
@@ -18658,8 +29918,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=585;
-						item1=33;
+						item0=3102;
+						item1=2584;
 						class CustomData
 						{
 							role=1;
@@ -18667,7 +29927,7 @@ class Mission
 					};
 				};
 			};
-			id=582;
+			id=3099;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -18692,7 +29952,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item223
+		class Item356
 		{
 			dataType="Group";
 			side="Independent";
@@ -18704,7 +29964,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1536.0054,5.0014391,763.23743};
+						position[]={1508.7744,5.0014391,1363.7883};
 					};
 					side="Independent";
 					flags=6;
@@ -18718,7 +29978,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=587;
+					id=3104;
 					type="I_Soldier_SL_F";
 				};
 				class Item1
@@ -18726,7 +29986,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1541.0054,5.0014391,761.58704};
+						position[]={1513.7744,5.0014391,1362.1379};
 					};
 					side="Independent";
 					flags=4;
@@ -18739,7 +29999,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=588;
+					id=3105;
 					type="I_medic_F";
 				};
 			};
@@ -18747,7 +30007,7 @@ class Mission
 			{
 				name="GrpAAF_CSL";
 			};
-			id=586;
+			id=3103;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -18772,7 +30032,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item224
+		class Item357
 		{
 			dataType="Group";
 			side="Independent";
@@ -18784,7 +30044,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1536.6616,5.0014391,734.91907};
+						position[]={1509.4307,5.0014391,1335.47};
 					};
 					side="Independent";
 					flags=6;
@@ -18798,7 +30058,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=590;
+					id=3107;
 					type="I_Soldier_TL_F";
 				};
 				class Item1
@@ -18806,7 +30066,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1541.6616,5.0014391,733.26868};
+						position[]={1514.4307,5.0014391,1333.8196};
 					};
 					side="Independent";
 					flags=4;
@@ -18820,7 +30080,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=591;
+					id=3108;
 					type="I_Soldier_AR_F";
 				};
 				class Item2
@@ -18828,7 +30088,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1531.6616,5.0014391,733.26868};
+						position[]={1504.4307,5.0014391,1333.8196};
 					};
 					side="Independent";
 					flags=4;
@@ -18842,7 +30102,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=592;
+					id=3109;
 					type="I_Soldier_AR_F";
 				};
 				class Item3
@@ -18850,7 +30110,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1546.6616,5.0014391,730.52942};
+						position[]={1519.4307,5.0014391,1331.0803};
 					};
 					side="Independent";
 					flags=4;
@@ -18864,7 +30124,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=593;
+					id=3110;
 					type="I_Soldier_LAT_F";
 				};
 				class Item4
@@ -18872,7 +30132,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1526.6616,5.0014391,730.52942};
+						position[]={1499.4307,5.0014391,1331.0803};
 					};
 					side="Independent";
 					flags=4;
@@ -18885,7 +30145,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=594;
+					id=3111;
 					type="I_soldier_F";
 				};
 				class Item5
@@ -18893,7 +30153,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1551.6616,5.0014391,725.98254};
+						position[]={1524.4307,5.0014391,1326.5334};
 					};
 					side="Independent";
 					flags=4;
@@ -18906,7 +30166,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=595;
+					id=3112;
 					type="I_soldier_F";
 				};
 			};
@@ -18914,7 +30174,7 @@ class Mission
 			{
 				name="GrpAAF_C1";
 			};
-			id=589;
+			id=3106;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -18939,7 +30199,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item225
+		class Item358
 		{
 			dataType="Group";
 			side="Independent";
@@ -18951,7 +30211,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1536.3423,5.0014391,709.98157};
+						position[]={1509.1113,5.0014391,1310.5325};
 					};
 					side="Independent";
 					flags=6;
@@ -18965,7 +30225,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=597;
+					id=3114;
 					type="I_Soldier_TL_F";
 				};
 				class Item1
@@ -18973,7 +30233,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1541.3423,5.0014391,708.3302};
+						position[]={1514.1113,5.0014391,1308.8811};
 					};
 					side="Independent";
 					flags=4;
@@ -18987,7 +30247,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=598;
+					id=3115;
 					type="I_Soldier_AR_F";
 				};
 				class Item2
@@ -18995,7 +30255,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1531.3423,5.0014391,708.3302};
+						position[]={1504.1113,5.0014391,1308.8811};
 					};
 					side="Independent";
 					flags=4;
@@ -19009,7 +30269,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=599;
+					id=3116;
 					type="I_Soldier_AR_F";
 				};
 				class Item3
@@ -19017,7 +30277,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1546.3423,5.0014391,705.59192};
+						position[]={1519.1113,5.0014391,1306.1428};
 					};
 					side="Independent";
 					flags=4;
@@ -19031,7 +30291,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=600;
+					id=3117;
 					type="I_Soldier_LAT_F";
 				};
 				class Item4
@@ -19039,7 +30299,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1526.3423,5.0014391,705.59192};
+						position[]={1499.1113,5.0014391,1306.1428};
 					};
 					side="Independent";
 					flags=4;
@@ -19052,7 +30312,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=601;
+					id=3118;
 					type="I_soldier_F";
 				};
 				class Item5
@@ -19060,7 +30320,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1551.3423,5.0014391,701.04504};
+						position[]={1524.1113,5.0014391,1301.5959};
 					};
 					side="Independent";
 					flags=4;
@@ -19073,7 +30333,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=602;
+					id=3119;
 					type="I_soldier_F";
 				};
 			};
@@ -19081,7 +30341,7 @@ class Mission
 			{
 				name="GrpAAF_C2";
 			};
-			id=596;
+			id=3113;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -19106,7 +30366,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item226
+		class Item359
 		{
 			dataType="Group";
 			side="Independent";
@@ -19118,7 +30378,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1535.4771,5.0014391,674.50134};
+						position[]={1508.246,5.0014391,1275.052};
 					};
 					side="Independent";
 					flags=6;
@@ -19132,7 +30392,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=604;
+					id=3121;
 					type="I_crew_F";
 				};
 				class Item1
@@ -19140,7 +30400,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1535.4771,5.0014391,674.50134};
+						position[]={1508.246,5.0014391,1275.052};
 					};
 					side="Independent";
 					flags=4;
@@ -19154,7 +30414,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=605;
+					id=3122;
 					type="I_crew_F";
 				};
 				class Item2
@@ -19162,7 +30422,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1535.4771,5.0014391,674.50134};
+						position[]={1508.246,5.0014391,1275.052};
 					};
 					side="Independent";
 					flags=4;
@@ -19175,7 +30435,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=606;
+					id=3123;
 					type="I_crew_F";
 				};
 			};
@@ -19195,8 +30455,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=604;
-						item1=34;
+						item0=3121;
+						item1=2585;
 						class CustomData
 						{
 							role=2;
@@ -19206,8 +30466,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=605;
-						item1=34;
+						item0=3122;
+						item1=2585;
 						class CustomData
 						{
 							role=2;
@@ -19217,8 +30477,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=606;
-						item1=34;
+						item0=3123;
+						item1=2585;
 						class CustomData
 						{
 							role=1;
@@ -19226,7 +30486,7 @@ class Mission
 					};
 				};
 			};
-			id=603;
+			id=3120;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -19251,7 +30511,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item227
+		class Item360
 		{
 			dataType="Group";
 			side="Independent";
@@ -19263,7 +30523,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1594.408,5.0014391,761.87897};
+						position[]={1567.177,5.0014391,1362.4299};
 					};
 					side="Independent";
 					flags=6;
@@ -19277,7 +30537,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=608;
+					id=3125;
 					type="I_Soldier_TL_F";
 				};
 				class Item1
@@ -19285,7 +30545,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1599.4077,5.0014391,760.22864};
+						position[]={1572.1768,5.0014391,1360.7795};
 					};
 					side="Independent";
 					flags=4;
@@ -19298,7 +30558,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=609;
+					id=3126;
 					type="I_Soldier_AR_F";
 				};
 				class Item2
@@ -19306,7 +30566,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1590.245,5.0014391,760.25702};
+						position[]={1563.014,5.0014391,1360.8079};
 					};
 					side="Independent";
 					flags=4;
@@ -19320,7 +30580,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1224;
+					id=3127;
 					type="I_Soldier_AAR_F";
 				};
 			};
@@ -19328,7 +30588,7 @@ class Mission
 			{
 				name="GrpAAF_MMG1";
 			};
-			id=607;
+			id=3124;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -19353,7 +30613,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item228
+		class Item361
 		{
 			dataType="Group";
 			side="Independent";
@@ -19365,7 +30625,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1594.433,5.0014391,747.13696};
+						position[]={1567.202,5.0014391,1347.6877};
 					};
 					side="Independent";
 					flags=6;
@@ -19379,7 +30639,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=611;
+					id=3129;
 					type="I_Soldier_TL_F";
 				};
 				class Item1
@@ -19387,7 +30647,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1599.4331,5.0014391,745.48645};
+						position[]={1572.2021,5.0014391,1346.0374};
 					};
 					side="Independent";
 					flags=4;
@@ -19400,7 +30660,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=612;
+					id=3130;
 					type="I_Soldier_AR_F";
 				};
 				class Item2
@@ -19408,7 +30668,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1590.271,5.0014391,745.51501};
+						position[]={1563.04,5.0014391,1346.0659};
 					};
 					side="Independent";
 					flags=4;
@@ -19422,7 +30682,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1225;
+					id=3131;
 					type="I_Soldier_AAR_F";
 				};
 			};
@@ -19430,7 +30690,7 @@ class Mission
 			{
 				name="GrpAAF_MMG2";
 			};
-			id=610;
+			id=3128;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -19455,7 +30715,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item229
+		class Item362
 		{
 			dataType="Group";
 			side="Independent";
@@ -19467,7 +30727,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1594.5389,5.0014391,733.86096};
+						position[]={1567.308,5.0014391,1334.4119};
 						angles[]={0,0.030927233,0};
 					};
 					side="Independent";
@@ -19482,7 +30742,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=614;
+					id=3133;
 					type="I_Soldier_TL_F";
 				};
 				class Item1
@@ -19490,7 +30750,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1599.5386,5.0014391,732.21106};
+						position[]={1572.3076,5.0014391,1332.762};
 					};
 					side="Independent";
 					flags=4;
@@ -19503,7 +30763,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=615;
+					id=3134;
 					type="I_Soldier_AT_F";
 				};
 				class Item2
@@ -19511,7 +30771,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1590.376,5.0014391,732.23999};
+						position[]={1563.145,5.0014391,1332.7908};
 						angles[]={0,0.030927233,0};
 					};
 					side="Independent";
@@ -19526,7 +30786,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1226;
+					id=3135;
 					type="I_Soldier_AAT_F";
 				};
 			};
@@ -19534,7 +30794,7 @@ class Mission
 			{
 				name="GrpAAF_MAT1";
 			};
-			id=613;
+			id=3132;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -19559,7 +30819,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item230
+		class Item363
 		{
 			dataType="Group";
 			side="Independent";
@@ -19571,7 +30831,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1594.958,5.0014391,722.32599};
+						position[]={1567.7271,5.0014391,1322.877};
 					};
 					side="Independent";
 					flags=6;
@@ -19585,7 +30845,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=617;
+					id=3137;
 					type="I_Soldier_TL_F";
 				};
 				class Item1
@@ -19593,7 +30853,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1599.9575,5.0014391,720.6759};
+						position[]={1572.7266,5.0014391,1321.2268};
 					};
 					side="Independent";
 					flags=4;
@@ -19606,7 +30866,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=618;
+					id=3138;
 					type="I_Soldier_AT_F";
 				};
 				class Item2
@@ -19614,7 +30874,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1590.7949,5.0014391,720.70502};
+						position[]={1563.564,5.0014391,1321.2559};
 					};
 					side="Independent";
 					flags=4;
@@ -19628,7 +30888,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1227;
+					id=3139;
 					type="I_Soldier_AAT_F";
 				};
 			};
@@ -19636,7 +30896,7 @@ class Mission
 			{
 				name="GrpAAF_MAT2";
 			};
-			id=616;
+			id=3136;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -19661,7 +30921,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item231
+		class Item364
 		{
 			dataType="Group";
 			side="Independent";
@@ -19673,7 +30933,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1594.9038,5.0014391,709.20618};
+						position[]={1567.6729,5.0014391,1309.7571};
 					};
 					side="Independent";
 					flags=6;
@@ -19687,7 +30947,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=620;
+					id=3141;
 					type="I_Soldier_TL_F";
 				};
 				class Item1
@@ -19695,7 +30955,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1599.9038,5.0014391,707.55579};
+						position[]={1572.6729,5.0014391,1308.1067};
 					};
 					side="Independent";
 					flags=4;
@@ -19708,7 +30968,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=621;
+					id=3142;
 					type="I_support_MG_F";
 				};
 			};
@@ -19716,7 +30976,7 @@ class Mission
 			{
 				name="GrpAAF_HMG1";
 			};
-			id=619;
+			id=3140;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -19741,7 +31001,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item232
+		class Item365
 		{
 			dataType="Group";
 			side="Independent";
@@ -19753,7 +31013,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1594.89,5.0014391,697.82697};
+						position[]={1567.6591,5.0014391,1298.3779};
 					};
 					side="Independent";
 					flags=6;
@@ -19767,7 +31027,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=623;
+					id=3144;
 					type="I_Soldier_TL_F";
 				};
 				class Item1
@@ -19775,7 +31035,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1599.8901,5.0014391,696.17688};
+						position[]={1572.6592,5.0014391,1296.7278};
 					};
 					side="Independent";
 					flags=4;
@@ -19788,7 +31048,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=624;
+					id=3145;
 					type="I_Soldier_AT_F";
 				};
 				class Item2
@@ -19796,7 +31056,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1590.7279,5.0014391,696.20599};
+						position[]={1563.4969,5.0014391,1296.7568};
 					};
 					side="Independent";
 					flags=4;
@@ -19810,7 +31070,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1228;
+					id=3146;
 					type="I_Soldier_AAT_F";
 				};
 			};
@@ -19818,7 +31078,7 @@ class Mission
 			{
 				name="GrpAAF_HAT1";
 			};
-			id=622;
+			id=3143;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -19843,7 +31103,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item233
+		class Item366
 		{
 			dataType="Group";
 			side="Independent";
@@ -19855,7 +31115,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1594.8911,5.0014391,685.70813};
+						position[]={1567.6602,5.0014391,1286.259};
 					};
 					side="Independent";
 					flags=6;
@@ -19869,7 +31129,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=626;
+					id=3148;
 					type="I_support_AMort_F";
 				};
 				class Item1
@@ -19877,7 +31137,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1599.8911,5.0014391,684.05774};
+						position[]={1572.6602,5.0014391,1284.6086};
 					};
 					side="Independent";
 					flags=4;
@@ -19890,7 +31150,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=627;
+					id=3149;
 					type="I_support_Mort_F";
 				};
 			};
@@ -19898,7 +31158,7 @@ class Mission
 			{
 				name="GrpAAF_MTR1";
 			};
-			id=625;
+			id=3147;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -19923,7 +31183,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item234
+		class Item367
 		{
 			dataType="Group";
 			side="Independent";
@@ -19935,7 +31195,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1594.6801,5.0014391,673.70996};
+						position[]={1567.4491,5.0014391,1274.2607};
 					};
 					side="Independent";
 					flags=6;
@@ -19949,7 +31209,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=629;
+					id=3151;
 					type="I_Soldier_AAA_F";
 				};
 				class Item1
@@ -19957,7 +31217,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1599.6802,5.0014391,672.05969};
+						position[]={1572.4492,5.0014391,1272.6106};
 					};
 					side="Independent";
 					flags=4;
@@ -19970,7 +31230,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=630;
+					id=3152;
 					type="I_Soldier_AA_F";
 				};
 				class Item2
@@ -19978,7 +31238,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1590.5179,5.0014391,672.08801};
+						position[]={1563.287,5.0014391,1272.6389};
 					};
 					side="Independent";
 					flags=4;
@@ -19992,7 +31252,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1196;
+					id=3153;
 					type="I_Soldier_AAA_F";
 				};
 			};
@@ -20000,7 +31260,7 @@ class Mission
 			{
 				name="GrpAAF_MSAM1";
 			};
-			id=628;
+			id=3150;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -20025,7 +31285,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item235
+		class Item368
 		{
 			dataType="Group";
 			side="Independent";
@@ -20037,7 +31297,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1594.856,5.0014391,660.52844};
+						position[]={1567.625,5.0014391,1261.0793};
 					};
 					side="Independent";
 					flags=6;
@@ -20051,7 +31311,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=632;
+					id=3155;
 					type="I_Soldier_AAA_F";
 				};
 				class Item1
@@ -20059,7 +31319,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1599.856,5.0014391,658.87805};
+						position[]={1572.625,5.0014391,1259.429};
 					};
 					side="Independent";
 					flags=4;
@@ -20072,7 +31332,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=633;
+					id=3156;
 					type="I_Soldier_AA_F";
 				};
 			};
@@ -20080,7 +31340,7 @@ class Mission
 			{
 				name="GrpAAF_HSAM1";
 			};
-			id=631;
+			id=3154;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -20105,7 +31365,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item236
+		class Item369
 		{
 			dataType="Group";
 			side="Independent";
@@ -20117,7 +31377,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1595.2114,5.0014391,649.46985};
+						position[]={1567.9805,5.0014391,1250.0208};
 					};
 					side="Independent";
 					flags=6;
@@ -20131,7 +31391,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=635;
+					id=3158;
 					type="I_Spotter_F";
 				};
 				class Item1
@@ -20139,7 +31399,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1600.2114,5.0014391,647.81946};
+						position[]={1572.9805,5.0014391,1248.3704};
 					};
 					side="Independent";
 					flags=4;
@@ -20152,7 +31412,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=636;
+					id=3159;
 					type="I_Sniper_F";
 				};
 			};
@@ -20160,7 +31420,7 @@ class Mission
 			{
 				name="GrpAAF_ST1";
 			};
-			id=634;
+			id=3157;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -20185,7 +31445,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item237
+		class Item370
 		{
 			dataType="Group";
 			side="Independent";
@@ -20197,7 +31457,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1595.6235,5.0014391,636.34192};
+						position[]={1568.3926,5.0014391,1236.8928};
 					};
 					side="Independent";
 					flags=6;
@@ -20210,7 +31470,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=638;
+					id=3161;
 					type="I_engineer_F";
 				};
 				class Item1
@@ -20218,7 +31478,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1600.6235,5.0014391,634.6925};
+						position[]={1573.3926,5.0014391,1235.2434};
 					};
 					side="Independent";
 					flags=4;
@@ -20231,7 +31491,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=639;
+					id=3162;
 					type="I_engineer_F";
 				};
 				class Item2
@@ -20239,7 +31499,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1590.6235,5.0014391,634.6925};
+						position[]={1563.3926,5.0014391,1235.2434};
 					};
 					side="Independent";
 					flags=4;
@@ -20252,7 +31512,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=640;
+					id=3163;
 					type="I_engineer_F";
 				};
 				class Item3
@@ -20260,7 +31520,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1605.6235,5.0014391,631.95227};
+						position[]={1578.3926,5.0014391,1232.5032};
 					};
 					side="Independent";
 					flags=4;
@@ -20273,7 +31533,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=641;
+					id=3164;
 					type="I_engineer_F";
 				};
 			};
@@ -20281,7 +31541,7 @@ class Mission
 			{
 				name="GrpAAF_ENG1";
 			};
-			id=637;
+			id=3160;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -20306,7 +31566,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item238
+		class Item371
 		{
 			dataType="Group";
 			side="Independent";
@@ -20318,7 +31578,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1596.231,5.0014391,623.49915};
+						position[]={1569,5.0014391,1224.05};
 					};
 					side="Independent";
 					flags=6;
@@ -20332,7 +31592,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=643;
+					id=3166;
 					type="I_diver_F";
 				};
 				class Item1
@@ -20340,7 +31600,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1601.231,5.0014391,621.84875};
+						position[]={1574,5.0014391,1222.3997};
 					};
 					side="Independent";
 					flags=4;
@@ -20354,7 +31614,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=644;
+					id=3167;
 					type="I_diver_F";
 				};
 				class Item2
@@ -20362,7 +31622,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1591.231,5.0014391,621.84875};
+						position[]={1564,5.0014391,1222.3997};
 					};
 					side="Independent";
 					flags=4;
@@ -20376,7 +31636,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=645;
+					id=3168;
 					type="I_diver_F";
 				};
 				class Item3
@@ -20384,7 +31644,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1606.231,5.0014391,619.1095};
+						position[]={1579,5.0014391,1219.6604};
 					};
 					side="Independent";
 					flags=4;
@@ -20398,7 +31658,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=646;
+					id=3169;
 					type="I_diver_F";
 				};
 			};
@@ -20406,7 +31666,7 @@ class Mission
 			{
 				name="GrpAAF_DT1";
 			};
-			id=642;
+			id=3165;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -20431,7 +31691,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item239
+		class Item372
 		{
 			dataType="Group";
 			side="Independent";
@@ -20443,7 +31703,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1409.1245,5.1983914,652.10193};
+						position[]={1381.894,5.1764393,1252.6531};
 					};
 					side="Independent";
 					flags=6;
@@ -20457,16 +31717,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=648;
+					id=3171;
 					type="I_crew_F";
-					atlOffset=0.19695234;
+					atlOffset=0.17500019;
 				};
 				class Item1
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1409.1245,5.1983914,652.10193};
+						position[]={1381.894,5.1764393,1252.6531};
 					};
 					side="Independent";
 					flags=4;
@@ -20480,16 +31740,16 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=649;
+					id=3172;
 					type="I_crew_F";
-					atlOffset=0.19695234;
+					atlOffset=0.17500019;
 				};
 				class Item2
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1409.1245,5.1983914,652.10193};
+						position[]={1381.894,5.1764393,1252.6531};
 					};
 					side="Independent";
 					flags=4;
@@ -20502,9 +31762,9 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=650;
+					id=3173;
 					type="I_crew_F";
-					atlOffset=0.19695234;
+					atlOffset=0.17500019;
 				};
 			};
 			class Attributes
@@ -20523,8 +31783,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=648;
-						item1=81;
+						item0=3171;
+						item1=2632;
 						class CustomData
 						{
 							role=2;
@@ -20534,8 +31794,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=649;
-						item1=81;
+						item0=3172;
+						item1=2632;
 						class CustomData
 						{
 							role=2;
@@ -20545,8 +31805,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=650;
-						item1=81;
+						item0=3173;
+						item1=2632;
 						class CustomData
 						{
 							role=1;
@@ -20554,8 +31814,8 @@ class Mission
 					};
 				};
 			};
-			id=647;
-			atlOffset=0.17517948;
+			id=3170;
+			atlOffset=0.17500019;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -20580,7 +31840,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item240
+		class Item373
 		{
 			dataType="Group";
 			side="Independent";
@@ -20592,7 +31852,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1452.3257,5.0014391,649.75525};
+						position[]={1425.095,5.0014391,1250.306};
 					};
 					side="Independent";
 					flags=6;
@@ -20606,7 +31866,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=652;
+					id=3175;
 					type="I_crew_F";
 				};
 				class Item1
@@ -20614,7 +31874,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1452.3257,5.0014391,649.75525};
+						position[]={1425.095,5.0014391,1250.306};
 					};
 					side="Independent";
 					flags=4;
@@ -20628,7 +31888,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=653;
+					id=3176;
 					type="I_crew_F";
 				};
 				class Item2
@@ -20636,7 +31896,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1452.3257,5.0014391,649.75525};
+						position[]={1425.095,5.0014391,1250.306};
 					};
 					side="Independent";
 					flags=4;
@@ -20649,7 +31909,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=654;
+					id=3177;
 					type="I_crew_F";
 				};
 			};
@@ -20669,8 +31929,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=652;
-						item1=82;
+						item0=3175;
+						item1=2633;
 						class CustomData
 						{
 							role=2;
@@ -20680,8 +31940,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=653;
-						item1=82;
+						item0=3176;
+						item1=2633;
 						class CustomData
 						{
 							role=2;
@@ -20691,8 +31951,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=654;
-						item1=82;
+						item0=3177;
+						item1=2633;
 						class CustomData
 						{
 							role=1;
@@ -20700,8 +31960,7 @@ class Mission
 					};
 				};
 			};
-			id=651;
-			atlOffset=-0.021772861;
+			id=3174;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -20726,7 +31985,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item241
+		class Item374
 		{
 			dataType="Group";
 			side="Independent";
@@ -20738,7 +31997,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1493.9966,5.0014391,650.44958};
+						position[]={1466.766,5.0014391,1251};
 					};
 					side="Independent";
 					flags=6;
@@ -20752,7 +32011,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=656;
+					id=3179;
 					type="I_crew_F";
 				};
 				class Item1
@@ -20760,7 +32019,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1493.9966,5.0014391,650.44958};
+						position[]={1466.766,5.0014391,1251};
 					};
 					side="Independent";
 					flags=4;
@@ -20774,7 +32033,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=657;
+					id=3180;
 					type="I_crew_F";
 				};
 				class Item2
@@ -20782,7 +32041,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1493.9966,5.0014391,650.44958};
+						position[]={1466.766,5.0014391,1251};
 					};
 					side="Independent";
 					flags=4;
@@ -20795,7 +32054,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=658;
+					id=3181;
 					type="I_crew_F";
 				};
 			};
@@ -20815,8 +32074,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=656;
-						item1=36;
+						item0=3179;
+						item1=2587;
 						class CustomData
 						{
 							role=2;
@@ -20826,8 +32085,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=657;
-						item1=36;
+						item0=3180;
+						item1=2587;
 						class CustomData
 						{
 							role=2;
@@ -20837,8 +32096,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=658;
-						item1=36;
+						item0=3181;
+						item1=2587;
 						class CustomData
 						{
 							role=1;
@@ -20846,8 +32105,7 @@ class Mission
 					};
 				};
 			};
-			id=655;
-			atlOffset=-0.18000031;
+			id=3178;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -20872,7 +32130,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item242
+		class Item375
 		{
 			dataType="Group";
 			side="Independent";
@@ -20884,7 +32142,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1409.0298,5.0014391,617.91455};
+						position[]={1381.799,5.0014391,1218.4661};
 					};
 					side="Independent";
 					flags=6;
@@ -20898,7 +32156,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=660;
+					id=3183;
 					type="I_helipilot_F";
 				};
 				class Item1
@@ -20906,7 +32164,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1409.0298,5.0014391,617.91455};
+						position[]={1381.799,5.0014391,1218.4661};
 					};
 					side="Independent";
 					flags=4;
@@ -20920,7 +32178,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=661;
+					id=3184;
 					type="I_helipilot_F";
 				};
 			};
@@ -20940,8 +32198,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=660;
-						item1=2;
+						item0=3183;
+						item1=2553;
 						class CustomData
 						{
 							role=1;
@@ -20950,8 +32208,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=661;
-						item1=2;
+						item0=3184;
+						item1=2553;
 						class CustomData
 						{
 							role=2;
@@ -20960,8 +32218,7 @@ class Mission
 					};
 				};
 			};
-			id=659;
-			atlOffset=-0.024078369;
+			id=3182;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -20986,7 +32243,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item243
+		class Item376
 		{
 			dataType="Group";
 			side="Independent";
@@ -20998,7 +32255,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1452.1128,5.0014391,618.75342};
+						position[]={1424.882,5.0014391,1219.3041};
 					};
 					side="Independent";
 					flags=6;
@@ -21012,7 +32269,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=663;
+					id=3186;
 					type="I_helipilot_F";
 				};
 				class Item1
@@ -21020,7 +32277,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1452.1128,5.0014391,618.75342};
+						position[]={1424.882,5.0014391,1219.3041};
 					};
 					side="Independent";
 					flags=4;
@@ -21034,7 +32291,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=664;
+					id=3187;
 					type="I_helipilot_F";
 				};
 			};
@@ -21054,8 +32311,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=663;
-						item1=15;
+						item0=3186;
+						item1=2566;
 						class CustomData
 						{
 							role=1;
@@ -21064,8 +32321,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=664;
-						item1=15;
+						item0=3187;
+						item1=2566;
 						class CustomData
 						{
 							role=2;
@@ -21074,8 +32331,7 @@ class Mission
 					};
 				};
 			};
-			id=662;
-			atlOffset=-0.024078369;
+			id=3185;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -21100,7 +32356,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item244
+		class Item377
 		{
 			dataType="Group";
 			side="Independent";
@@ -21112,7 +32368,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1494.3599,5.0014391,619.59424};
+						position[]={1467.129,5.0014391,1220.145};
 					};
 					side="Independent";
 					flags=6;
@@ -21126,7 +32382,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=666;
+					id=3189;
 					type="I_helipilot_F";
 				};
 				class Item1
@@ -21134,7 +32390,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1494.3599,5.0014391,619.59424};
+						position[]={1467.129,5.0014391,1220.145};
 					};
 					side="Independent";
 					flags=4;
@@ -21148,7 +32404,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=667;
+					id=3190;
 					type="I_helipilot_F";
 				};
 			};
@@ -21168,8 +32424,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=666;
-						item1=16;
+						item0=3189;
+						item1=2567;
 						class CustomData
 						{
 							role=1;
@@ -21178,8 +32434,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=667;
-						item1=16;
+						item0=3190;
+						item1=2567;
 						class CustomData
 						{
 							role=2;
@@ -21188,8 +32444,7 @@ class Mission
 					};
 				};
 			};
-			id=665;
-			atlOffset=-0.024078369;
+			id=3188;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -21214,7 +32469,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item245
+		class Item378
 		{
 			dataType="Group";
 			side="Independent";
@@ -21226,7 +32481,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1535.6772,5.0014391,620.25049};
+						position[]={1508.446,5.0014391,1220.801};
 					};
 					side="Independent";
 					flags=6;
@@ -21240,7 +32495,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=669;
+					id=3192;
 					type="I_helipilot_F";
 				};
 				class Item1
@@ -21248,7 +32503,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1535.6772,5.0014391,620.25049};
+						position[]={1508.446,5.0014391,1220.801};
 					};
 					side="Independent";
 					flags=4;
@@ -21262,7 +32517,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=670;
+					id=3193;
 					type="I_helipilot_F";
 				};
 			};
@@ -21282,8 +32537,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=669;
-						item1=17;
+						item0=3192;
+						item1=2568;
 						class CustomData
 						{
 							role=1;
@@ -21292,8 +32547,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=670;
-						item1=17;
+						item0=3193;
+						item1=2568;
 						class CustomData
 						{
 							role=2;
@@ -21302,8 +32557,7 @@ class Mission
 					};
 				};
 			};
-			id=668;
-			atlOffset=-0.024078369;
+			id=3191;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -21328,7 +32582,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item246
+		class Item379
 		{
 			dataType="Group";
 			side="Independent";
@@ -21340,7 +32594,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1408.8267,5.0014391,586.5531};
+						position[]={1381.5959,5.0014391,1187.104};
 					};
 					side="Independent";
 					flags=6;
@@ -21354,7 +32608,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=672;
+					id=3195;
 					type="I_helipilot_F";
 				};
 				class Item1
@@ -21362,7 +32616,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1408.8267,5.0014391,586.5531};
+						position[]={1381.5959,5.0014391,1187.104};
 					};
 					side="Independent";
 					flags=4;
@@ -21376,7 +32630,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=673;
+					id=3196;
 					type="I_helipilot_F";
 				};
 			};
@@ -21396,8 +32650,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=672;
-						item1=37;
+						item0=3195;
+						item1=2588;
 						class CustomData
 						{
 							role=1;
@@ -21406,8 +32660,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=673;
-						item1=37;
+						item0=3196;
+						item1=2588;
 						class CustomData
 						{
 							role=2;
@@ -21416,7 +32670,7 @@ class Mission
 					};
 				};
 			};
-			id=671;
+			id=3194;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -21441,7 +32695,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item247
+		class Item380
 		{
 			dataType="Group";
 			side="West";
@@ -21453,7 +32707,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={446.25912,5.0014391,757.14838};
+						position[]={439.71899,5.0014391,948.96918};
 					};
 					side="West";
 					flags=6;
@@ -21467,7 +32721,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=680;
+					id=3198;
 					type="B_G_officer_F";
 				};
 				class Item1
@@ -21475,7 +32729,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={451.25912,5.0014391,755.49799};
+						position[]={444.71899,5.0014391,947.31879};
 					};
 					side="West";
 					flags=4;
@@ -21489,7 +32743,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=681;
+					id=3199;
 					type="B_G_officer_F";
 				};
 				class Item2
@@ -21497,7 +32751,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={441.7894,5.0014391,754.13666};
+						position[]={435.24927,5.0014391,945.95746};
 					};
 					side="West";
 					flags=4;
@@ -21510,7 +32764,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=682;
+					id=3200;
 					type="B_G_Soldier_F";
 				};
 				class Item3
@@ -21518,7 +32772,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={456.25912,5.0014391,752.75775};
+						position[]={449.71899,5.0014391,944.57855};
 					};
 					side="West";
 					flags=4;
@@ -21531,7 +32785,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=683;
+					id=3201;
 					type="B_G_medic_F";
 				};
 			};
@@ -21539,7 +32793,7 @@ class Mission
 			{
 				name="GrpFIA_CO";
 			};
-			id=679;
+			id=3197;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -21564,7 +32818,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item248
+		class Item381
 		{
 			dataType="Group";
 			side="West";
@@ -21576,7 +32830,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={445.72104,5.2133446,732.78412};
+						position[]={439.18091,5.2133446,924.60492};
 					};
 					side="West";
 					flags=6;
@@ -21590,7 +32844,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=685;
+					id=3203;
 					type="B_G_officer_F";
 					atlOffset=0.21190548;
 					class CustomAttributes
@@ -21622,7 +32876,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={450.72104,5.2344303,731.13373};
+						position[]={444.18091,5.2344303,922.95453};
 					};
 					side="West";
 					flags=4;
@@ -21636,7 +32890,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=686;
+					id=3204;
 					type="B_G_officer_F";
 					atlOffset=0.23299122;
 					class CustomAttributes
@@ -21668,7 +32922,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={440.72104,5.1082706,731.13373};
+						position[]={434.18091,5.1082706,922.95453};
 					};
 					side="West";
 					flags=4;
@@ -21681,7 +32935,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=687;
+					id=3205;
 					type="B_G_Soldier_F";
 					atlOffset=0.10683155;
 					class CustomAttributes
@@ -21713,7 +32967,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={455.72104,5.1013861,728.39447};
+						position[]={449.18091,5.1013861,920.21527};
 					};
 					side="West";
 					flags=4;
@@ -21726,7 +32980,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=688;
+					id=3206;
 					type="B_G_medic_F";
 					atlOffset=0.099946976;
 					class CustomAttributes
@@ -21758,7 +33012,7 @@ class Mission
 			{
 				name="GrpFIA_DC";
 			};
-			id=684;
+			id=3202;
 			atlOffset=0.21190548;
 			class CustomAttributes
 			{
@@ -21784,7 +33038,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item249
+		class Item382
 		{
 			dataType="Group";
 			side="West";
@@ -21796,7 +33050,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={482.41245,5.0014391,756.539};
+						position[]={475.87231,5.0014391,948.3598};
 					};
 					side="West";
 					flags=6;
@@ -21810,7 +33064,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=690;
+					id=3208;
 					type="B_G_Soldier_SL_F";
 					class CustomAttributes
 					{
@@ -21841,7 +33095,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={487.41245,5.0014391,754.88861};
+						position[]={480.87231,5.0014391,946.70941};
 					};
 					side="West";
 					flags=4;
@@ -21854,7 +33108,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=691;
+					id=3209;
 					type="B_G_medic_F";
 					class CustomAttributes
 					{
@@ -21885,7 +33139,7 @@ class Mission
 			{
 				name="GrpFIA_ASL";
 			};
-			id=689;
+			id=3207;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -21910,7 +33164,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item250
+		class Item383
 		{
 			dataType="Group";
 			side="West";
@@ -21922,7 +33176,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={482.97202,5.0014391,735.03412};
+						position[]={476.43188,5.0014391,926.85492};
 					};
 					side="West";
 					flags=6;
@@ -21936,7 +33190,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=693;
+					id=3211;
 					type="B_G_Soldier_TL_F";
 					class CustomAttributes
 					{
@@ -21967,7 +33221,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={487.97202,5.0913763,733.38373};
+						position[]={481.43188,5.0913763,925.20453};
 					};
 					side="West";
 					flags=4;
@@ -21981,7 +33235,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=694;
+					id=3212;
 					type="B_G_Soldier_AR_F";
 					atlOffset=0.08993721;
 					class CustomAttributes
@@ -22013,7 +33267,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={477.97202,5.0014391,733.38373};
+						position[]={471.43188,5.0014391,925.20453};
 					};
 					side="West";
 					flags=4;
@@ -22027,7 +33281,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=695;
+					id=3213;
 					type="B_G_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -22058,7 +33312,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={492.97202,5.248991,730.64447};
+						position[]={486.43188,5.248991,922.46527};
 					};
 					side="West";
 					flags=4;
@@ -22072,7 +33326,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=696;
+					id=3214;
 					type="B_G_Soldier_LAT_F";
 					atlOffset=0.24755192;
 					class CustomAttributes
@@ -22104,7 +33358,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={472.97202,5.0014391,730.64447};
+						position[]={466.43188,5.0014391,922.46527};
 					};
 					side="West";
 					flags=4;
@@ -22117,7 +33371,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=697;
+					id=3215;
 					type="B_G_Soldier_F";
 					class CustomAttributes
 					{
@@ -22148,7 +33402,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={497.97202,5.0014391,726.0976};
+						position[]={491.43188,5.0014391,917.9184};
 					};
 					side="West";
 					flags=4;
@@ -22161,7 +33415,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=698;
+					id=3216;
 					type="B_G_Soldier_F";
 					class CustomAttributes
 					{
@@ -22192,7 +33446,7 @@ class Mission
 			{
 				name="GrpFIA_A1";
 			};
-			id=692;
+			id=3210;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -22217,7 +33471,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item251
+		class Item384
 		{
 			dataType="Group";
 			side="West";
@@ -22229,7 +33483,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={482.73569,5.0014391,711.15521};
+						position[]={476.19556,5.0014391,902.97601};
 					};
 					side="West";
 					flags=6;
@@ -22243,7 +33497,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=700;
+					id=3218;
 					type="B_G_Soldier_TL_F";
 					class CustomAttributes
 					{
@@ -22274,7 +33528,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={487.73569,5.0014391,709.50482};
+						position[]={481.19556,5.0014391,901.32562};
 					};
 					side="West";
 					flags=4;
@@ -22288,7 +33542,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=701;
+					id=3219;
 					type="B_G_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -22319,7 +33573,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={477.73569,5.0014391,709.50482};
+						position[]={471.19556,5.0014391,901.32562};
 					};
 					side="West";
 					flags=4;
@@ -22333,7 +33587,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=702;
+					id=3220;
 					type="B_G_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -22364,7 +33618,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={492.73569,5.0014391,706.76556};
+						position[]={486.19556,5.0014391,898.58636};
 					};
 					side="West";
 					flags=4;
@@ -22378,7 +33632,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=703;
+					id=3221;
 					type="B_G_Soldier_LAT_F";
 					class CustomAttributes
 					{
@@ -22409,7 +33663,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={472.73569,5.0014391,706.76556};
+						position[]={466.19556,5.0014391,898.58636};
 					};
 					side="West";
 					flags=4;
@@ -22422,7 +33676,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=704;
+					id=3222;
 					type="B_G_Soldier_F";
 					class CustomAttributes
 					{
@@ -22453,7 +33707,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={497.73569,5.0014391,702.21869};
+						position[]={491.19556,5.0014391,894.03949};
 					};
 					side="West";
 					flags=4;
@@ -22466,7 +33720,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=705;
+					id=3223;
 					type="B_G_Soldier_F";
 					class CustomAttributes
 					{
@@ -22497,7 +33751,7 @@ class Mission
 			{
 				name="GrpFIA_A2";
 			};
-			id=699;
+			id=3217;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -22522,7 +33776,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item252
+		class Item385
 		{
 			dataType="Group";
 			side="West";
@@ -22534,7 +33788,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={523.09412,5.0014391,756.49213};
+						position[]={516.5542,5.0014391,948.31293};
 					};
 					side="West";
 					flags=6;
@@ -22548,7 +33802,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=707;
+					id=3225;
 					type="B_G_Soldier_SL_F";
 					class CustomAttributes
 					{
@@ -22579,7 +33833,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={528.09412,5.0014391,754.84174};
+						position[]={521.5542,5.0014391,946.66254};
 					};
 					side="West";
 					flags=4;
@@ -22592,7 +33846,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=708;
+					id=3226;
 					type="B_G_medic_F";
 					class CustomAttributes
 					{
@@ -22623,7 +33877,7 @@ class Mission
 			{
 				name="GrpFIA_BSL";
 			};
-			id=706;
+			id=3224;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -22648,7 +33902,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item253
+		class Item386
 		{
 			dataType="Group";
 			side="West";
@@ -22660,7 +33914,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={523.86072,5.0014391,734.79681};
+						position[]={517.3208,5.0014391,926.61761};
 					};
 					side="West";
 					flags=6;
@@ -22674,7 +33928,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=710;
+					id=3228;
 					type="B_G_Soldier_TL_F";
 				};
 				class Item1
@@ -22682,7 +33936,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={528.86072,5.0014391,733.1474};
+						position[]={522.3208,5.0014391,924.9682};
 					};
 					side="West";
 					flags=4;
@@ -22696,7 +33950,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=711;
+					id=3229;
 					type="B_G_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -22727,7 +33981,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={518.86072,5.0014391,733.1474};
+						position[]={512.3208,5.0014391,924.9682};
 					};
 					side="West";
 					flags=4;
@@ -22741,7 +33995,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=712;
+					id=3230;
 					type="B_G_Soldier_AR_F";
 				};
 				class Item3
@@ -22749,7 +34003,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={533.86072,5.0014391,730.40717};
+						position[]={527.3208,5.0014391,922.22797};
 					};
 					side="West";
 					flags=4;
@@ -22763,7 +34017,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=713;
+					id=3231;
 					type="B_G_Soldier_LAT_F";
 				};
 				class Item4
@@ -22771,7 +34025,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={513.86072,5.0014391,730.40717};
+						position[]={507.3208,5.0014391,922.22797};
 					};
 					side="West";
 					flags=4;
@@ -22784,7 +34038,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=714;
+					id=3232;
 					type="B_G_Soldier_F";
 				};
 				class Item5
@@ -22792,7 +34046,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={538.86072,5.0014391,725.86127};
+						position[]={532.3208,5.0014391,917.68207};
 					};
 					side="West";
 					flags=4;
@@ -22805,7 +34059,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=715;
+					id=3233;
 					type="B_G_Soldier_F";
 				};
 			};
@@ -22813,7 +34067,7 @@ class Mission
 			{
 				name="GrpFIA_B1";
 			};
-			id=709;
+			id=3227;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -22838,7 +34092,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item254
+		class Item387
 		{
 			dataType="Group";
 			side="West";
@@ -22850,7 +34104,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={523.30115,5.0014391,711.56927};
+						position[]={516.76123,5.0014391,903.39008};
 					};
 					side="West";
 					flags=6;
@@ -22864,7 +34118,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=717;
+					id=3235;
 					type="B_G_Soldier_TL_F";
 				};
 				class Item1
@@ -22872,7 +34126,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={528.30115,5.0014391,709.91791};
+						position[]={521.76123,5.0014391,901.73871};
 					};
 					side="West";
 					flags=4;
@@ -22886,7 +34140,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=718;
+					id=3236;
 					type="B_G_Soldier_AR_F";
 				};
 				class Item2
@@ -22894,7 +34148,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={518.30115,5.0014391,709.91791};
+						position[]={511.76123,5.0014391,901.73871};
 					};
 					side="West";
 					flags=4;
@@ -22908,7 +34162,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=719;
+					id=3237;
 					type="B_G_Soldier_AR_F";
 				};
 				class Item3
@@ -22916,7 +34170,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={533.30115,5.0014391,707.17865};
+						position[]={526.76123,5.0014391,898.99945};
 					};
 					side="West";
 					flags=4;
@@ -22930,7 +34184,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=720;
+					id=3238;
 					type="B_G_Soldier_LAT_F";
 				};
 				class Item4
@@ -22938,7 +34192,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={513.30115,5.0014391,707.17865};
+						position[]={506.76123,5.0014391,898.99945};
 					};
 					side="West";
 					flags=4;
@@ -22951,7 +34205,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=721;
+					id=3239;
 					type="B_G_Soldier_F";
 				};
 				class Item5
@@ -22959,7 +34213,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={538.30115,5.0014391,702.63177};
+						position[]={531.76123,5.0014391,894.45258};
 					};
 					side="West";
 					flags=4;
@@ -22972,7 +34226,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=722;
+					id=3240;
 					type="B_G_Soldier_F";
 				};
 			};
@@ -22980,7 +34234,7 @@ class Mission
 			{
 				name="GrpFIA_B2";
 			};
-			id=716;
+			id=3234;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -23005,7 +34259,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item255
+		class Item388
 		{
 			dataType="Group";
 			side="West";
@@ -23017,7 +34271,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={566.27771,5.3023081,755.89545};
+						position[]={559.73767,5.3023081,947.71625};
 					};
 					side="West";
 					flags=2;
@@ -23031,16 +34285,39 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=724;
+					id=3242;
 					type="B_G_Soldier_SL_F";
 					atlOffset=0.30086899;
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male06GRE";
+								};
+							};
+						};
+						nAttributes=1;
+					};
 				};
 				class Item1
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={571.27771,5.6464462,754.24506};
+						position[]={564.73767,5.6464462,946.06586};
 					};
 					side="West";
 					class Attributes
@@ -23052,16 +34329,39 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=725;
+					id=3243;
 					type="B_G_medic_F";
 					atlOffset=0.64500713;
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male06GRE";
+								};
+							};
+						};
+						nAttributes=1;
+					};
 				};
 			};
 			class Attributes
 			{
 				name="GrpFIA_CSL";
 			};
-			id=723;
+			id=3241;
 			atlOffset=0.30086899;
 			class CustomAttributes
 			{
@@ -23087,7 +34387,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item256
+		class Item389
 		{
 			dataType="Group";
 			side="West";
@@ -23099,7 +34399,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={566.67908,5.0014391,734.13568};
+						position[]={560.13904,5.0014391,925.95648};
 					};
 					side="West";
 					flags=6;
@@ -23113,7 +34413,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=727;
+					id=3245;
 					type="B_G_Soldier_TL_F";
 				};
 				class Item1
@@ -23121,7 +34421,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={571.67908,5.0014391,732.48627};
+						position[]={565.13904,5.0014391,924.30707};
 					};
 					side="West";
 					flags=4;
@@ -23135,7 +34435,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=728;
+					id=3246;
 					type="B_G_Soldier_AR_F";
 				};
 				class Item2
@@ -23143,7 +34443,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={561.67908,5.0014391,732.48627};
+						position[]={555.13904,5.0014391,924.30707};
 					};
 					side="West";
 					flags=4;
@@ -23157,7 +34457,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=729;
+					id=3247;
 					type="B_G_Soldier_AR_F";
 				};
 				class Item3
@@ -23165,7 +34465,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={576.67908,5.0014391,729.74603};
+						position[]={570.13904,5.0014391,921.56683};
 					};
 					side="West";
 					flags=4;
@@ -23179,7 +34479,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=730;
+					id=3248;
 					type="B_G_Soldier_LAT_F";
 				};
 				class Item4
@@ -23187,7 +34487,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={556.67908,5.0014391,729.74603};
+						position[]={550.13904,5.0014391,921.56683};
 					};
 					side="West";
 					flags=4;
@@ -23200,7 +34500,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=731;
+					id=3249;
 					type="B_G_Soldier_F";
 				};
 				class Item5
@@ -23208,7 +34508,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={581.67908,5.0014391,725.19916};
+						position[]={575.13904,5.0014391,917.01996};
 					};
 					side="West";
 					flags=4;
@@ -23221,7 +34521,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=732;
+					id=3250;
 					type="B_G_Soldier_F";
 				};
 			};
@@ -23229,7 +34529,7 @@ class Mission
 			{
 				name="GrpFIA_C1";
 			};
-			id=726;
+			id=3244;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -23254,7 +34554,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item257
+		class Item390
 		{
 			dataType="Group";
 			side="West";
@@ -23266,7 +34566,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={566.98376,5.0014391,711.03217};
+						position[]={560.44373,5.0014391,902.85297};
 					};
 					side="West";
 					flags=6;
@@ -23280,7 +34580,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=734;
+					id=3252;
 					type="B_G_Soldier_TL_F";
 				};
 				class Item1
@@ -23288,7 +34588,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={571.98376,5.0014391,709.38177};
+						position[]={565.44373,5.0014391,901.20258};
 					};
 					side="West";
 					flags=4;
@@ -23302,7 +34602,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=735;
+					id=3253;
 					type="B_G_Soldier_AR_F";
 				};
 				class Item2
@@ -23310,7 +34610,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={561.98376,5.0014391,709.38177};
+						position[]={555.44373,5.0014391,901.20258};
 					};
 					side="West";
 					flags=4;
@@ -23324,7 +34624,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=736;
+					id=3254;
 					type="B_G_Soldier_AR_F";
 				};
 				class Item3
@@ -23332,7 +34632,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={576.98376,5.0014391,706.64252};
+						position[]={570.44373,5.0014391,898.46332};
 					};
 					side="West";
 					flags=4;
@@ -23346,7 +34646,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=737;
+					id=3255;
 					type="B_G_Soldier_LAT_F";
 				};
 				class Item4
@@ -23354,7 +34654,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={556.98376,5.0014391,706.64252};
+						position[]={550.44373,5.0014391,898.46332};
 					};
 					side="West";
 					flags=4;
@@ -23367,7 +34667,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=738;
+					id=3256;
 					type="B_G_Soldier_F";
 				};
 				class Item5
@@ -23375,7 +34675,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={581.98376,5.0014391,702.09467};
+						position[]={575.44373,5.0014391,893.91547};
 					};
 					side="West";
 					flags=4;
@@ -23388,7 +34688,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=739;
+					id=3257;
 					type="B_G_Soldier_F";
 				};
 			};
@@ -23396,7 +34696,7 @@ class Mission
 			{
 				name="GrpFIA_C2";
 			};
-			id=733;
+			id=3251;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -23421,7 +34721,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item258
+		class Item391
 		{
 			dataType="Group";
 			side="West";
@@ -23433,7 +34733,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={602.96899,5.153439,756.117};
+						position[]={596.42896,5.153439,947.93781};
 					};
 					side="West";
 					flags=6;
@@ -23447,7 +34747,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=741;
+					id=3259;
 					type="B_G_Soldier_TL_F";
 					atlOffset=0.15199995;
 				};
@@ -23456,7 +34756,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={607.96912,5.2476587,754.46674};
+						position[]={601.42908,5.2476587,946.28754};
 					};
 					side="West";
 					flags=4;
@@ -23469,7 +34769,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=742;
+					id=3260;
 					type="B_G_Soldier_AR_F";
 					atlOffset=0.24621964;
 				};
@@ -23478,7 +34778,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={598.80688,5.153439,754.49603};
+						position[]={592.26685,5.153439,946.31683};
 					};
 					side="West";
 					flags=4;
@@ -23492,7 +34792,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1214;
+					id=3261;
 					type="B_G_Soldier_lite_F";
 					atlOffset=0.15199995;
 				};
@@ -23501,7 +34801,7 @@ class Mission
 			{
 				name="GrpFIA_MMG1";
 			};
-			id=740;
+			id=3258;
 			atlOffset=0.15199995;
 			class CustomAttributes
 			{
@@ -23527,7 +34827,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item259
+		class Item392
 		{
 			dataType="Group";
 			side="West";
@@ -23539,7 +34839,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={602.82898,5.0014391,744.77802};
+						position[]={596.28894,5.0014391,936.59882};
 					};
 					side="West";
 					flags=6;
@@ -23553,7 +34853,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=744;
+					id=3263;
 					type="B_G_Soldier_TL_F";
 				};
 				class Item1
@@ -23561,7 +34861,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={607.82947,5.0014391,743.12787};
+						position[]={601.28943,5.0014391,934.94867};
 					};
 					side="West";
 					flags=4;
@@ -23574,7 +34874,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=745;
+					id=3264;
 					type="B_G_Soldier_AR_F";
 				};
 				class Item2
@@ -23582,7 +34882,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={598.66699,5.0014391,743.15698};
+						position[]={592.12695,5.0014391,934.97772};
 					};
 					side="West";
 					flags=4;
@@ -23596,7 +34896,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1215;
+					id=3265;
 					type="B_G_Soldier_lite_F";
 				};
 			};
@@ -23604,7 +34904,7 @@ class Mission
 			{
 				name="GrpFIA_MMG2";
 			};
-			id=743;
+			id=3262;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -23629,7 +34929,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item260
+		class Item393
 		{
 			dataType="Group";
 			side="West";
@@ -23641,7 +34941,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={603.17297,5.0014391,734.07001};
+						position[]={596.63293,5.0014391,925.89081};
 					};
 					side="West";
 					flags=6;
@@ -23655,7 +34955,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=747;
+					id=3267;
 					type="B_G_Soldier_TL_F";
 				};
 				class Item1
@@ -23663,7 +34963,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={608.17322,5.0014391,732.41986};
+						position[]={601.63318,5.0014391,924.24066};
 					};
 					side="West";
 					flags=4;
@@ -23676,7 +34976,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=748;
+					id=3268;
 					type="B_G_Soldier_LAT_F";
 				};
 				class Item2
@@ -23684,7 +34984,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={599.01099,5.0014391,732.44897};
+						position[]={592.47095,5.0014391,924.26971};
 					};
 					side="West";
 					flags=4;
@@ -23698,7 +34998,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1216;
+					id=3269;
 					type="B_G_Soldier_LAT_F";
 				};
 			};
@@ -23706,7 +35006,7 @@ class Mission
 			{
 				name="GrpFIA_MAT1";
 			};
-			id=746;
+			id=3266;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -23731,7 +35031,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item261
+		class Item394
 		{
 			dataType="Group";
 			side="West";
@@ -23743,7 +35043,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={603.086,5.0014391,722.08801};
+						position[]={596.5459,5.0014391,913.90881};
 					};
 					side="West";
 					flags=6;
@@ -23757,15 +35057,38 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=750;
+					id=3271;
 					type="B_G_Soldier_TL_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male06GRE";
+								};
+							};
+						};
+						nAttributes=1;
+					};
 				};
 				class Item1
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={608.0863,5.0014391,720.43744};
+						position[]={601.54626,5.0014391,912.25824};
 					};
 					side="West";
 					flags=4;
@@ -23779,15 +35102,38 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=751;
+					id=3272;
 					type="B_G_Soldier_LAT_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male06GRE";
+								};
+							};
+						};
+						nAttributes=1;
+					};
 				};
 				class Item2
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={598.92395,5.0014391,720.466};
+						position[]={592.38391,5.0014391,912.2868};
 					};
 					side="West";
 					flags=4;
@@ -23801,15 +35147,38 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1217;
+					id=3273;
 					type="B_G_Soldier_LAT_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male06GRE";
+								};
+							};
+						};
+						nAttributes=1;
+					};
 				};
 			};
 			class Attributes
 			{
 				name="GrpFIA_MAT2";
 			};
-			id=749;
+			id=3270;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -23834,7 +35203,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item262
+		class Item395
 		{
 			dataType="Group";
 			side="West";
@@ -23846,7 +35215,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={603.57458,5.0014391,711.18939};
+						position[]={597.03455,5.0014391,903.01019};
 					};
 					side="West";
 					flags=6;
@@ -23860,7 +35229,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=753;
+					id=3275;
 					type="B_G_Soldier_TL_F";
 				};
 				class Item1
@@ -23868,7 +35237,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={608.57458,5.0014391,709.539};
+						position[]={602.03455,5.0014391,901.3598};
 					};
 					side="West";
 					flags=4;
@@ -23881,7 +35250,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=754;
+					id=3276;
 					type="B_G_Soldier_AR_F";
 				};
 			};
@@ -23889,7 +35258,7 @@ class Mission
 			{
 				name="GrpFIA_HMG1";
 			};
-			id=752;
+			id=3274;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -23914,7 +35283,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item263
+		class Item396
 		{
 			dataType="Group";
 			side="West";
@@ -23926,7 +35295,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={603.39899,5.0014391,698.78601};
+						position[]={596.85889,5.0014391,890.60681};
 					};
 					side="West";
 					flags=6;
@@ -23940,7 +35309,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=756;
+					id=3278;
 					type="B_G_Soldier_TL_F";
 				};
 				class Item1
@@ -23948,7 +35317,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={608.3988,5.2301273,697.13568};
+						position[]={601.85876,5.2301273,888.95648};
 					};
 					side="West";
 					flags=4;
@@ -23962,7 +35331,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=757;
+					id=3279;
 					type="B_G_Soldier_LAT_F";
 					atlOffset=0.22868824;
 				};
@@ -23971,7 +35340,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={599.23596,5.0014391,697.164};
+						position[]={592.69592,5.0014391,888.9848};
 					};
 					side="West";
 					flags=4;
@@ -23985,7 +35354,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1218;
+					id=3280;
 					type="B_G_Soldier_LAT_F";
 				};
 			};
@@ -23993,7 +35362,7 @@ class Mission
 			{
 				name="GrpFIA_HAT1";
 			};
-			id=755;
+			id=3277;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -24018,7 +35387,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item264
+		class Item397
 		{
 			dataType="Group";
 			side="West";
@@ -24030,7 +35399,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={603.40076,5.0014391,687.01752};
+						position[]={596.86072,5.0014391,878.83832};
 					};
 					side="West";
 					flags=6;
@@ -24044,7 +35413,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=759;
+					id=3282;
 					type="B_G_Soldier_F";
 				};
 				class Item1
@@ -24052,7 +35421,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={608.40076,5.3897858,685.36713};
+						position[]={601.86072,5.3897858,877.18793};
 					};
 					side="West";
 					class Attributes
@@ -24065,7 +35434,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=760;
+					id=3283;
 					type="B_G_Soldier_A_F";
 					atlOffset=0.38834667;
 				};
@@ -24074,7 +35443,7 @@ class Mission
 			{
 				name="GrpFIA_MTR1";
 			};
-			id=758;
+			id=3281;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -24099,7 +35468,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item265
+		class Item398
 		{
 			dataType="Group";
 			side="West";
@@ -24111,7 +35480,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={603.40002,5.0014391,674.5};
+						position[]={596.85999,5.0014391,866.3208};
 					};
 					side="West";
 					flags=6;
@@ -24125,15 +35494,38 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=762;
+					id=3285;
 					type="B_G_Soldier_LAT_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male01GRE";
+								};
+							};
+						};
+						nAttributes=1;
+					};
 				};
 				class Item1
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={608.39978,5.5413675,672.84955};
+						position[]={601.85974,5.5413675,864.67035};
 					};
 					side="West";
 					class Attributes
@@ -24146,16 +35538,39 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=763;
+					id=3286;
 					type="B_G_Soldier_LAT_F";
 					atlOffset=0.53992844;
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male01GRE";
+								};
+							};
+						};
+						nAttributes=1;
+					};
 				};
 				class Item2
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={599.23694,5.0014391,672.87799};
+						position[]={592.6969,5.0014391,864.69879};
 					};
 					side="West";
 					flags=4;
@@ -24169,15 +35584,38 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1172;
+					id=3287;
 					type="B_G_Soldier_LAT_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male01GRE";
+								};
+							};
+						};
+						nAttributes=1;
+					};
 				};
 			};
 			class Attributes
 			{
 				name="GrpFIA_MSAM1";
 			};
-			id=761;
+			id=3284;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -24202,7 +35640,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item266
+		class Item399
 		{
 			dataType="Group";
 			side="West";
@@ -24214,7 +35652,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={603.29919,5.0014391,661.72552};
+						position[]={596.75916,5.0014391,853.54633};
 					};
 					side="West";
 					flags=6;
@@ -24228,7 +35666,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=765;
+					id=3289;
 					type="B_G_Soldier_LAT_F";
 				};
 				class Item1
@@ -24236,7 +35674,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={608.29919,5.0014391,660.07513};
+						position[]={601.75916,5.0014391,851.89594};
 					};
 					side="West";
 					flags=4;
@@ -24250,7 +35688,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=766;
+					id=3290;
 					type="B_G_Soldier_LAT_F";
 				};
 			};
@@ -24258,7 +35696,7 @@ class Mission
 			{
 				name="GrpFIA_HSAM1";
 			};
-			id=764;
+			id=3288;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -24283,7 +35721,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item267
+		class Item400
 		{
 			dataType="Group";
 			side="West";
@@ -24295,7 +35733,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={603.17224,5.0014391,650.82025};
+						position[]={596.6322,5.0014391,842.64105};
 					};
 					side="West";
 					flags=6;
@@ -24309,7 +35747,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=768;
+					id=3292;
 					type="B_G_Soldier_M_F";
 				};
 				class Item1
@@ -24317,7 +35755,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={608.17224,5.0014391,649.16986};
+						position[]={601.6322,5.0014391,840.99066};
 					};
 					side="West";
 					flags=4;
@@ -24331,7 +35769,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=769;
+					id=3293;
 					type="B_G_Soldier_M_F";
 				};
 			};
@@ -24339,7 +35777,7 @@ class Mission
 			{
 				name="GrpFIA_ST1";
 			};
-			id=767;
+			id=3291;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -24364,7 +35802,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item268
+		class Item401
 		{
 			dataType="Group";
 			side="West";
@@ -24376,7 +35814,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={603.94373,5.0014391,638.47357};
+						position[]={597.40369,5.0014391,830.29437};
 					};
 					side="West";
 					flags=6;
@@ -24390,7 +35828,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=771;
+					id=3295;
 					type="B_G_engineer_F";
 				};
 				class Item1
@@ -24398,7 +35836,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={608.94373,5.0014391,636.82318};
+						position[]={602.40369,5.0014391,828.64398};
 					};
 					side="West";
 					flags=4;
@@ -24411,7 +35849,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=772;
+					id=3296;
 					type="B_G_engineer_F";
 				};
 				class Item2
@@ -24419,7 +35857,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={598.94373,5.0014391,636.82318};
+						position[]={592.40369,5.0014391,828.64398};
 					};
 					side="West";
 					flags=4;
@@ -24432,7 +35870,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=773;
+					id=3297;
 					type="B_G_engineer_F";
 				};
 				class Item3
@@ -24440,7 +35878,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={613.94373,5.0014391,634.08392};
+						position[]={607.40369,5.0014391,825.90472};
 					};
 					side="West";
 					flags=4;
@@ -24453,7 +35891,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=774;
+					id=3298;
 					type="B_G_engineer_F";
 				};
 			};
@@ -24461,7 +35899,7 @@ class Mission
 			{
 				name="GrpFIA_ENG1";
 			};
-			id=770;
+			id=3294;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -24486,7 +35924,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item269
+		class Item402
 		{
 			dataType="Group";
 			side="West";
@@ -24498,7 +35936,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={604.48364,5.0014391,626.65302};
+						position[]={597.94397,5.0014391,818.474};
 					};
 					side="West";
 					flags=6;
@@ -24512,7 +35950,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=776;
+					id=3300;
 					type="B_G_engineer_F";
 				};
 				class Item1
@@ -24520,7 +35958,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={604.48364,5.0014391,626.65302};
+						position[]={597.94397,5.0014391,818.474};
 					};
 					side="West";
 					flags=4;
@@ -24534,7 +35972,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=777;
+					id=3301;
 					type="B_G_engineer_F";
 				};
 			};
@@ -24554,8 +35992,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=776;
-						item1=72;
+						item0=3300;
+						item1=2623;
 						class CustomData
 						{
 							role=1;
@@ -24564,8 +36002,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=777;
-						item1=72;
+						item0=3301;
+						item1=2623;
 						class CustomData
 						{
 							role=2;
@@ -24574,7 +36012,7 @@ class Mission
 					};
 				};
 			};
-			id=775;
+			id=3299;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -24599,7 +36037,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item270
+		class Item403
 		{
 			dataType="Group";
 			side="West";
@@ -24611,7 +36049,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={448.18201,5.0014391,686.51398};
+						position[]={441.642,5.0014391,878.33398};
 					};
 					side="West";
 					flags=4;
@@ -24624,7 +36062,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1032;
+					id=3303;
 					type="B_G_Soldier_F";
 					class CustomAttributes
 					{
@@ -24655,7 +36093,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={448.18201,5.0014391,686.51398};
+						position[]={441.642,5.0014391,878.33398};
 					};
 					side="West";
 					flags=6;
@@ -24669,7 +36107,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1033;
+					id=3304;
 					type="B_G_Soldier_F";
 					class CustomAttributes
 					{
@@ -24712,8 +36150,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=1032;
-						item1=85;
+						item0=3303;
+						item1=2636;
 						class CustomData
 						{
 							role=1;
@@ -24722,8 +36160,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=1033;
-						item1=85;
+						item0=3304;
+						item1=2636;
 						class CustomData
 						{
 							role=2;
@@ -24732,7 +36170,7 @@ class Mission
 					};
 				};
 			};
-			id=778;
+			id=3302;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -24750,14 +36188,14 @@ class Mission
 									"STRING"
 								};
 							};
-							value="FIA IFV1 -";
+							value="FIA TECH1 -";
 						};
 					};
 				};
 				nAttributes=1;
 			};
 		};
-		class Item271
+		class Item404
 		{
 			dataType="Group";
 			side="West";
@@ -24769,7 +36207,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={482.90601,5.0014391,686.43097};
+						position[]={476.36499,5.0014391,878.25098};
 					};
 					side="West";
 					flags=6;
@@ -24783,7 +36221,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1030;
+					id=3306;
 					type="B_G_Soldier_F";
 					class CustomAttributes
 					{
@@ -24814,7 +36252,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={482.90601,5.0014391,686.43097};
+						position[]={476.36499,5.0014391,878.25098};
 					};
 					side="West";
 					flags=4;
@@ -24827,7 +36265,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1031;
+					id=3307;
 					type="B_G_Soldier_F";
 					class CustomAttributes
 					{
@@ -24870,8 +36308,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=1030;
-						item1=86;
+						item0=3306;
+						item1=2637;
 						class CustomData
 						{
 							role=2;
@@ -24881,8 +36319,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=1031;
-						item1=86;
+						item0=3307;
+						item1=2637;
 						class CustomData
 						{
 							role=1;
@@ -24890,7 +36328,7 @@ class Mission
 					};
 				};
 			};
-			id=781;
+			id=3305;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -24908,14 +36346,14 @@ class Mission
 									"STRING"
 								};
 							};
-							value="FIA IFV2 -";
+							value="FIA TECH2 -";
 						};
 					};
 				};
 				nAttributes=1;
 			};
 		};
-		class Item272
+		class Item405
 		{
 			dataType="Group";
 			side="Civilian";
@@ -24927,7 +36365,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2589.6348,5.1613512,725.10815};
+						position[]={2535,5.0014391,513.04999};
 					};
 					side="Civilian";
 					flags=6;
@@ -24939,12 +36377,30 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=790;
+					id=3309;
 					type="C_journalist_F";
-					atlOffset=0.15991211;
 					class CustomAttributes
 					{
 						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male01GRE";
+								};
+							};
+						};
+						class Attribute1
 						{
 							property="pitch";
 							expression="_this setpitch _value;";
@@ -24963,18 +36419,17 @@ class Mission
 								};
 							};
 						};
-						nAttributes=1;
+						nAttributes=2;
 					};
 				};
 			};
 			class Attributes
 			{
-			name="GrpCIV_R1";
+				name="GrpCIV_R1";
 			};
-			id=789;
-			atlOffset=0.15991211;
+			id=3308;
 		};
-		class Item273
+		class Item406
 		{
 			dataType="Group";
 			side="Civilian";
@@ -24986,7 +36441,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={2642.2625,5.0014391,721.59937};
+						position[]={2587.6277,5.0014391,509.5412};
 					};
 					side="Civilian";
 					flags=6;
@@ -24998,7 +36453,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=792;
+					id=3311;
 					type="C_journalist_F";
 					class CustomAttributes
 					{
@@ -25027,69 +36482,69 @@ class Mission
 			};
 			class Attributes
 			{
-			name="GrpCIV_R2";
+				name="GrpCIV_R2";
 			};
-			id=791;
+			id=3310;
 		};
-		class Item274
+		class Item407
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={2264.3303,5,729.32227};
+				position[]={2315.217,5,527.50098};
 			};
 			name="F3_Zeus";
 			isPlayable=1;
-			id=793;
+			id=3312;
 			type="VirtualCurator_F";
 		};
-		class Item275
+		class Item408
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={2264.9143,5.2476444,718.24805};
+				position[]={2315.801,5.2476444,516.42676};
 			};
 			name="F3_Zeus_1";
 			isPlayable=1;
-			id=794;
+			id=3313;
 			type="VirtualCurator_F";
 			atlOffset=0.24764442;
 		};
-		class Item276
+		class Item409
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={2266.3958,5.3839951,707.53711};
+				position[]={2317.2825,5.3839951,505.71582};
 			};
 			name="F3_Zeus_2";
 			isPlayable=1;
-			id=795;
+			id=3314;
 			type="VirtualCurator_F";
 			atlOffset=0.38399506;
 		};
-		class Item277
+		class Item410
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={2266.8528,5.6081486,696.99023};
+				position[]={2317.7395,5.6081486,495.16895};
 			};
 			name="F3_Zeus_3";
 			isPlayable=1;
-			id=796;
+			id=3315;
 			type="VirtualCurator_F";
 			atlOffset=0.60814857;
 		};
-		class Item278
+		class Item411
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1386.3022,5,759.53918};
+				position[]={1359.0713,5,1360.0901};
 			};
-			id=797;
+			id=3316;
 			type="SupportProvider_Virtual_CAS_Heli";
 			class CustomAttributes
 			{
@@ -25172,14 +36627,14 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item279
+		class Item412
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1386.7388,5,729.61243};
+				position[]={1359.5078,5,1330.1633};
 			};
-			id=798;
+			id=3317;
 			type="SupportProvider_Virtual_CAS_Heli";
 			class CustomAttributes
 			{
@@ -25262,14 +36717,14 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item280
+		class Item413
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
 				position[]={2355.054,5,1372.686};
 			};
-			id=799;
+			id=3318;
 			type="SupportProvider_Virtual_CAS_Heli";
 			class CustomAttributes
 			{
@@ -25352,14 +36807,14 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item281
+		class Item414
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
 				position[]={2355.7756,5,1347.9272};
 			};
-			id=800;
+			id=3319;
 			type="SupportProvider_Virtual_CAS_Heli";
 			class CustomAttributes
 			{
@@ -25442,14 +36897,14 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item282
+		class Item415
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={432.98569,5.7177486,729.02344};
+				position[]={426.44556,5.7177486,920.84424};
 			};
-			id=801;
+			id=3320;
 			type="SupportProvider_Virtual_CAS_Heli";
 			atlOffset=0.71774864;
 			class CustomAttributes
@@ -25533,14 +36988,14 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item283
+		class Item416
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={431.84018,5.4597912,752.30078};
+				position[]={425.30005,5.4597912,944.12158};
 			};
-			id=802;
+			id=3321;
 			type="SupportProvider_Virtual_CAS_Heli";
 			atlOffset=0.45979118;
 			class CustomAttributes
@@ -25624,14 +37079,14 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item284
+		class Item417
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
 				position[]={413.42789,5,1345.2402};
 			};
-			id=803;
+			id=3322;
 			type="SupportProvider_Virtual_CAS_Heli";
 			class CustomAttributes
 			{
@@ -25714,14 +37169,14 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item285
+		class Item418
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
 				position[]={413.20621,5,1367.6445};
 			};
-			id=804;
+			id=3323;
 			type="SupportProvider_Virtual_CAS_Heli";
 			class CustomAttributes
 			{
@@ -25804,88 +37259,88 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item286
+		class Item419
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
 				position[]={408.92496,5,1367.7412};
 			};
-			id=813;
+			id=3324;
 			type="SupportProvider_Artillery";
 		};
-		class Item287
+		class Item420
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={428.39584,5.8610754,728.56641};
+				position[]={421.85571,5.8610754,920.38721};
 			};
-			id=814;
+			id=3325;
 			type="SupportProvider_Artillery";
 			atlOffset=0.8610754;
 		};
-		class Item288
+		class Item421
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
 				position[]={409.14664,5,1345.3369};
 			};
-			id=815;
+			id=3326;
 			type="SupportProvider_Artillery";
 		};
-		class Item289
+		class Item422
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1382.4575,5,729.70911};
+				position[]={1355.2266,5,1330.26};
 			};
-			id=816;
+			id=3327;
 			type="SupportProvider_Artillery";
 		};
-		class Item290
+		class Item423
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1382.021,5,759.63586};
+				position[]={1354.79,5,1360.1868};
 			};
-			id=817;
+			id=3328;
 			type="SupportProvider_Artillery";
 		};
-		class Item291
+		class Item424
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
 				position[]={2351.7932,5,1347.4478};
 			};
-			id=818;
+			id=3329;
 			type="SupportProvider_Artillery";
 		};
-		class Item292
+		class Item425
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
 				position[]={2350.7717,5,1372.7827};
 			};
-			id=819;
+			id=3330;
 			type="SupportProvider_Artillery";
 		};
-		class Item293
+		class Item426
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={427.55893,5,752.39648};
+				position[]={421.0188,5,944.21729};
 			};
-			id=820;
+			id=3331;
 			type="SupportProvider_Artillery";
 		};
-		class Item294
+		class Item427
 		{
 			dataType="Group";
 			side="Independent";
@@ -25897,7 +37352,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1379.5668,5.0014391,1372.6985};
+						position[]={1384.9258,5.0014391,960.14246};
 					};
 					side="Independent";
 					flags=6;
@@ -25910,7 +37365,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=827;
+					id=3333;
 					type="I_C_Soldier_Para_2_F";
 					class CustomAttributes
 					{
@@ -25941,7 +37396,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1385.2201,5.0014391,1369.9319};
+						position[]={1390.5791,5.0014391,957.37585};
 					};
 					side="Independent";
 					flags=5;
@@ -25954,7 +37409,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=824;
+					id=3334;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
@@ -25985,7 +37440,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1374.6039,5.0014391,1369.6145};
+						position[]={1379.9629,5.0014391,957.05847};
 					};
 					side="Independent";
 					flags=5;
@@ -25997,7 +37452,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=825;
+					id=3335;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
@@ -26028,7 +37483,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1390.0951,5.0014391,1367.7346};
+						position[]={1395.4541,5.0014391,955.17859};
 					};
 					side="Independent";
 					flags=5;
@@ -26040,7 +37495,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=826;
+					id=3336;
 					type="I_C_Soldier_Para_3_F";
 					class CustomAttributes
 					{
@@ -26071,7 +37526,7 @@ class Mission
 			{
 				name="GrpSyn_CO";
 			};
-			id=823;
+			id=3332;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -26096,7 +37551,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item295
+		class Item428
 		{
 			dataType="Group";
 			side="Independent";
@@ -26108,7 +37563,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1379.5072,5.0014391,1344.0295};
+						position[]={1384.8662,5.0014391,931.47351};
 					};
 					side="Independent";
 					flags=6;
@@ -26121,7 +37576,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=842;
+					id=3338;
 					type="I_C_Soldier_Para_2_F";
 					class CustomAttributes
 					{
@@ -26152,7 +37607,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1384.9408,5.0014391,1341.219};
+						position[]={1390.2998,5.0014391,928.66296};
 					};
 					side="Independent";
 					flags=5;
@@ -26165,7 +37620,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=839;
+					id=3339;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
@@ -26196,7 +37651,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1374.5209,5.0014391,1341.3157};
+						position[]={1379.8799,5.0014391,928.75964};
 					};
 					side="Independent";
 					flags=5;
@@ -26208,7 +37663,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=840;
+					id=3340;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
@@ -26239,7 +37694,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1389.8158,5.0014391,1339.0217};
+						position[]={1395.1748,5.0014391,926.4657};
 					};
 					side="Independent";
 					flags=5;
@@ -26251,7 +37706,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=841;
+					id=3341;
 					type="I_C_Soldier_Para_3_F";
 					class CustomAttributes
 					{
@@ -26282,7 +37737,7 @@ class Mission
 			{
 				name="GrpSyn_DC";
 			};
-			id=838;
+			id=3337;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -26307,7 +37762,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item296
+		class Item429
 		{
 			dataType="Group";
 			side="Independent";
@@ -26319,7 +37774,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1420.1244,5.0014391,1372.6526};
+						position[]={1425.4834,5.0014391,960.09656};
 					};
 					side="Independent";
 					flags=6;
@@ -26332,7 +37787,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=855;
+					id=3343;
 					type="I_C_Soldier_Para_2_F";
 					class CustomAttributes
 					{
@@ -26363,7 +37818,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1425.2299,5.0014391,1369.6653};
+						position[]={1430.5889,5.0014391,957.10925};
 					};
 					side="Independent";
 					flags=5;
@@ -26375,7 +37830,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=854;
+					id=3344;
 					type="I_C_Soldier_Para_3_F";
 					class CustomAttributes
 					{
@@ -26406,7 +37861,7 @@ class Mission
 			{
 				name="GrpSyn_ASL";
 			};
-			id=853;
+			id=3342;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -26431,7 +37886,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item297
+		class Item430
 		{
 			dataType="Group";
 			side="Independent";
@@ -26443,7 +37898,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1419.9926,5.0014391,1346.175};
+						position[]={1425.3516,5.0014391,933.61902};
 					};
 					side="Independent";
 					flags=6;
@@ -26456,7 +37911,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=862;
+					id=3346;
 					type="I_C_Soldier_Para_2_F";
 					class CustomAttributes
 					{
@@ -26487,7 +37942,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1425.097,5.0014391,1343.1877};
+						position[]={1430.4561,5.0014391,930.63171};
 					};
 					side="Independent";
 					flags=4;
@@ -26500,7 +37955,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=857;
+					id=3347;
 					type="I_C_Soldier_Para_4_F";
 					class CustomAttributes
 					{
@@ -26531,7 +37986,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1414.8724,5.0014391,1343.262};
+						position[]={1420.2314,5.0014391,930.70593};
 					};
 					side="Independent";
 					flags=4;
@@ -26544,7 +37999,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=858;
+					id=3348;
 					type="I_C_Soldier_Para_4_F";
 					class CustomAttributes
 					{
@@ -26575,7 +38030,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1429.933,5.0014391,1339.9065};
+						position[]={1435.292,5.0014391,927.35046};
 					};
 					side="Independent";
 					flags=5;
@@ -26588,7 +38043,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=859;
+					id=3349;
 					type="I_C_Soldier_Para_5_F";
 					class CustomAttributes
 					{
@@ -26619,7 +38074,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1410.4662,5.0014391,1339.5042};
+						position[]={1415.8252,5.0014391,926.94812};
 					};
 					side="Independent";
 					flags=5;
@@ -26631,7 +38086,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=860;
+					id=3350;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
@@ -26662,7 +38117,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1435.9994,5.0014391,1336.0823};
+						position[]={1441.3584,5.0014391,923.52625};
 					};
 					side="Independent";
 					flags=5;
@@ -26674,7 +38129,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=861;
+					id=3351;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
@@ -26705,7 +38160,7 @@ class Mission
 			{
 				name="GrpSyn_A1";
 			};
-			id=856;
+			id=3345;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -26730,7 +38185,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item298
+		class Item431
 		{
 			dataType="Group";
 			side="Independent";
@@ -26742,7 +38197,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1420.4545,5.0014391,1316.8792};
+						position[]={1425.8135,5.0014391,904.32312};
 					};
 					side="Independent";
 					flags=6;
@@ -26755,7 +38210,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=869;
+					id=3353;
 					type="I_C_Soldier_Para_2_F";
 					class CustomAttributes
 					{
@@ -26786,7 +38241,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1425.5599,5.0014391,1313.8918};
+						position[]={1430.9189,5.0014391,901.33582};
 					};
 					side="Independent";
 					flags=4;
@@ -26799,7 +38254,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=864;
+					id=3354;
 					type="I_C_Soldier_Para_4_F";
 					class CustomAttributes
 					{
@@ -26830,7 +38285,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1415.3353,5.0014391,1313.967};
+						position[]={1420.6943,5.0014391,901.41101};
 					};
 					side="Independent";
 					flags=4;
@@ -26843,7 +38298,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=865;
+					id=3355;
 					type="I_C_Soldier_Para_4_F";
 					class CustomAttributes
 					{
@@ -26874,7 +38329,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1430.3959,5.0014391,1310.6106};
+						position[]={1435.7549,5.0014391,898.05457};
 					};
 					side="Independent";
 					flags=5;
@@ -26887,7 +38342,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=866;
+					id=3356;
 					type="I_C_Soldier_Para_5_F";
 					class CustomAttributes
 					{
@@ -26918,7 +38373,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1410.9291,5.0014391,1310.2092};
+						position[]={1416.2881,5.0014391,897.6532};
 					};
 					side="Independent";
 					flags=5;
@@ -26930,7 +38385,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=867;
+					id=3357;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
@@ -26961,7 +38416,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1436.4623,5.0014391,1306.7883};
+						position[]={1441.8213,5.0014391,894.2323};
 					};
 					side="Independent";
 					flags=5;
@@ -26973,7 +38428,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=868;
+					id=3358;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
@@ -27004,7 +38459,7 @@ class Mission
 			{
 				name="GrpSyn_A2";
 			};
-			id=863;
+			id=3352;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -27029,7 +38484,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item299
+		class Item432
 		{
 			dataType="Group";
 			side="Independent";
@@ -27041,7 +38496,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1460.2103,5.0014391,1371.6956};
+						position[]={1465.5693,5.0014391,959.13953};
 					};
 					side="Independent";
 					flags=6;
@@ -27054,7 +38509,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=872;
+					id=3360;
 					type="I_C_Soldier_Para_2_F";
 					class CustomAttributes
 					{
@@ -27085,7 +38540,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1465.3158,5.0014391,1368.7073};
+						position[]={1470.6748,5.0014391,956.15125};
 					};
 					side="Independent";
 					flags=5;
@@ -27097,7 +38552,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=871;
+					id=3361;
 					type="I_C_Soldier_Para_3_F";
 					class CustomAttributes
 					{
@@ -27128,7 +38583,7 @@ class Mission
 			{
 				name="GrpSyn_BSL";
 			};
-			id=870;
+			id=3359;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -27153,7 +38608,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item300
+		class Item433
 		{
 			dataType="Group";
 			side="Independent";
@@ -27165,7 +38620,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1460.1967,5.0014391,1346.0579};
+						position[]={1465.5557,5.0014391,933.50183};
 					};
 					side="Independent";
 					flags=6;
@@ -27178,7 +38633,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=879;
+					id=3363;
 					type="I_C_Soldier_Para_2_F";
 					class CustomAttributes
 					{
@@ -27209,7 +38664,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1465.3021,5.0014391,1343.0706};
+						position[]={1470.6611,5.0014391,930.51453};
 					};
 					side="Independent";
 					flags=4;
@@ -27222,7 +38677,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=874;
+					id=3364;
 					type="I_C_Soldier_Para_4_F";
 					class CustomAttributes
 					{
@@ -27253,7 +38708,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1455.0795,5.0014391,1343.1448};
+						position[]={1460.4385,5.0014391,930.58875};
 					};
 					side="Independent";
 					flags=4;
@@ -27266,7 +38721,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=875;
+					id=3365;
 					type="I_C_Soldier_Para_4_F";
 					class CustomAttributes
 					{
@@ -27297,7 +38752,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1470.1381,5.0014391,1339.7893};
+						position[]={1475.4971,5.0014391,927.23328};
 					};
 					side="Independent";
 					flags=5;
@@ -27310,7 +38765,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=876;
+					id=3366;
 					type="I_C_Soldier_Para_5_F";
 					class CustomAttributes
 					{
@@ -27341,7 +38796,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1450.6732,5.0014391,1339.387};
+						position[]={1456.0322,5.0014391,926.83093};
 					};
 					side="Independent";
 					flags=5;
@@ -27353,7 +38808,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=877;
+					id=3367;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
@@ -27384,7 +38839,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1476.2045,5.0014391,1335.967};
+						position[]={1481.5635,5.0014391,923.41101};
 					};
 					side="Independent";
 					flags=5;
@@ -27396,7 +38851,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=878;
+					id=3368;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
@@ -27427,7 +38882,7 @@ class Mission
 			{
 				name="GrpSyn_B1";
 			};
-			id=873;
+			id=3362;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -27452,7 +38907,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item301
+		class Item434
 		{
 			dataType="Group";
 			side="Independent";
@@ -27464,7 +38919,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1460.6029,5.0014391,1316.6848};
+						position[]={1465.9619,5.0014391,904.12878};
 					};
 					side="Independent";
 					flags=6;
@@ -27477,7 +38932,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=886;
+					id=3370;
 					type="I_C_Soldier_Para_2_F";
 					class CustomAttributes
 					{
@@ -27508,7 +38963,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1465.7094,5.0014391,1313.6975};
+						position[]={1471.0684,5.0014391,901.14148};
 					};
 					side="Independent";
 					flags=4;
@@ -27521,7 +38976,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=881;
+					id=3371;
 					type="I_C_Soldier_Para_4_F";
 					class CustomAttributes
 					{
@@ -27552,7 +39007,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1455.4857,5.0014391,1313.7717};
+						position[]={1460.8447,5.0014391,901.2157};
 					};
 					side="Independent";
 					flags=4;
@@ -27565,7 +39020,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=882;
+					id=3372;
 					type="I_C_Soldier_Para_4_F";
 					class CustomAttributes
 					{
@@ -27596,7 +39051,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1470.5443,5.0014391,1310.4172};
+						position[]={1475.9033,5.0014391,897.86121};
 					};
 					side="Independent";
 					flags=5;
@@ -27609,7 +39064,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=883;
+					id=3373;
 					type="I_C_Soldier_Para_5_F";
 					class CustomAttributes
 					{
@@ -27640,7 +39095,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1451.0795,5.0014391,1310.0139};
+						position[]={1456.4385,5.0014391,897.45789};
 					};
 					side="Independent";
 					flags=5;
@@ -27652,7 +39107,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=884;
+					id=3374;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
@@ -27683,7 +39138,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1476.6107,5.0014391,1306.594};
+						position[]={1481.9697,5.0014391,894.03796};
 					};
 					side="Independent";
 					flags=5;
@@ -27695,7 +39150,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=885;
+					id=3375;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
@@ -27726,7 +39181,7 @@ class Mission
 			{
 				name="GrpSyn_B2";
 			};
-			id=880;
+			id=3369;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -27751,7 +39206,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item302
+		class Item435
 		{
 			dataType="Group";
 			side="Independent";
@@ -27763,7 +39218,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1500.8724,5.0014391,1370.8596};
+						position[]={1506.2314,5.0014391,958.30359};
 					};
 					side="Independent";
 					flags=6;
@@ -27776,7 +39231,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=889;
+					id=3377;
 					type="I_C_Soldier_Para_2_F";
 					class CustomAttributes
 					{
@@ -27807,7 +39262,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1505.9779,5.0014391,1367.8723};
+						position[]={1511.3369,5.0014391,955.31628};
 					};
 					side="Independent";
 					flags=5;
@@ -27819,7 +39274,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=888;
+					id=3378;
 					type="I_C_Soldier_Para_3_F";
 					class CustomAttributes
 					{
@@ -27850,7 +39305,7 @@ class Mission
 			{
 				name="GrpSyn_CSL";
 			};
-			id=887;
+			id=3376;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -27875,7 +39330,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item303
+		class Item436
 		{
 			dataType="Group";
 			side="Independent";
@@ -27887,7 +39342,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1500.6595,5.0014391,1347.4036};
+						position[]={1506.0186,5.0014391,934.84753};
 					};
 					side="Independent";
 					flags=6;
@@ -27900,7 +39355,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=896;
+					id=3380;
 					type="I_C_Soldier_Para_2_F";
 					class CustomAttributes
 					{
@@ -27931,7 +39386,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1505.765,5.0014391,1344.4172};
+						position[]={1511.124,5.0014391,931.86121};
 					};
 					side="Independent";
 					flags=4;
@@ -27944,7 +39399,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=891;
+					id=3381;
 					type="I_C_Soldier_Para_4_F";
 					class CustomAttributes
 					{
@@ -27975,7 +39430,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1495.5404,5.0014391,1344.4905};
+						position[]={1500.8994,5.0014391,931.93445};
 					};
 					side="Independent";
 					flags=4;
@@ -27988,7 +39443,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=892;
+					id=3382;
 					type="I_C_Soldier_Para_4_F";
 					class CustomAttributes
 					{
@@ -28019,7 +39474,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1510.601,5.0014391,1341.135};
+						position[]={1515.96,5.0014391,928.57898};
 					};
 					side="Independent";
 					flags=5;
@@ -28032,7 +39487,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=893;
+					id=3383;
 					type="I_C_Soldier_Para_5_F";
 					class CustomAttributes
 					{
@@ -28063,7 +39518,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1491.1342,5.0014391,1340.7327};
+						position[]={1496.4932,5.0014391,928.17664};
 					};
 					side="Independent";
 					flags=5;
@@ -28075,7 +39530,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=894;
+					id=3384;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
@@ -28106,7 +39561,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1516.6674,5.0014391,1337.3137};
+						position[]={1522.0264,5.0014391,924.75769};
 					};
 					side="Independent";
 					flags=5;
@@ -28118,7 +39573,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=895;
+					id=3385;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
@@ -28149,7 +39604,7 @@ class Mission
 			{
 				name="GrpSyn_C1";
 			};
-			id=890;
+			id=3379;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -28174,7 +39629,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item304
+		class Item437
 		{
 			dataType="Group";
 			side="Independent";
@@ -28186,7 +39641,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1500.6595,5.0014391,1316.9084};
+						position[]={1506.0186,5.0014391,904.35242};
 					};
 					side="Independent";
 					flags=6;
@@ -28199,7 +39654,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=903;
+					id=3387;
 					type="I_C_Soldier_Para_2_F";
 					class CustomAttributes
 					{
@@ -28230,7 +39685,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1505.765,5.0014391,1313.9211};
+						position[]={1511.124,5.0014391,901.36511};
 					};
 					side="Independent";
 					flags=4;
@@ -28243,7 +39698,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=898;
+					id=3388;
 					type="I_C_Soldier_Para_4_F";
 					class CustomAttributes
 					{
@@ -28274,7 +39729,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1495.5424,5.0014391,1313.9954};
+						position[]={1500.9014,5.0014391,901.43933};
 					};
 					side="Independent";
 					flags=4;
@@ -28287,7 +39742,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=899;
+					id=3389;
 					type="I_C_Soldier_Para_4_F";
 					class CustomAttributes
 					{
@@ -28318,7 +39773,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1510.601,5.0014391,1310.6399};
+						position[]={1515.96,5.0014391,898.08386};
 					};
 					side="Independent";
 					flags=5;
@@ -28331,7 +39786,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=900;
+					id=3390;
 					type="I_C_Soldier_Para_5_F";
 				};
 				class Item4
@@ -28339,7 +39794,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1491.1361,5.0014391,1310.2375};
+						position[]={1496.4951,5.0014391,897.68152};
 					};
 					side="Independent";
 					flags=5;
@@ -28351,7 +39806,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=901;
+					id=3391;
 					type="I_C_Soldier_Para_1_F";
 				};
 				class Item5
@@ -28359,7 +39814,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1516.6674,5.0014391,1306.8176};
+						position[]={1522.0264,5.0014391,894.2616};
 					};
 					side="Independent";
 					flags=5;
@@ -28371,7 +39826,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=902;
+					id=3392;
 					type="I_C_Soldier_Para_1_F";
 				};
 			};
@@ -28379,7 +39834,7 @@ class Mission
 			{
 				name="GrpSyn_C2";
 			};
-			id=897;
+			id=3386;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -28404,7 +39859,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item305
+		class Item438
 		{
 			dataType="Group";
 			side="Independent";
@@ -28416,7 +39871,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1559.021,5.0014391,1369.0061};
+						position[]={1564.38,5.0014391,956.45007};
 					};
 					side="Independent";
 					flags=6;
@@ -28429,7 +39884,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=905;
+					id=3394;
 					type="I_C_Soldier_Para_2_F";
 					class CustomAttributes
 					{
@@ -28460,7 +39915,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1563.9642,5.0014391,1366.842};
+						position[]={1569.3232,5.0014391,954.28601};
 					};
 					side="Independent";
 					flags=5;
@@ -28472,7 +39927,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=906;
+					id=3395;
 					type="I_C_Soldier_Para_4_F";
 					class CustomAttributes
 					{
@@ -28503,7 +39958,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1554.8589,5.0014391,1367.384};
+						position[]={1560.2179,5.0014391,954.828};
 					};
 					side="Independent";
 					flags=4;
@@ -28516,7 +39971,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1219;
+					id=3396;
 					type="I_C_Soldier_Para_4_F";
 				};
 			};
@@ -28524,7 +39979,7 @@ class Mission
 			{
 				name="GrpSyn_MMG1";
 			};
-			id=904;
+			id=3393;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -28549,7 +40004,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item306
+		class Item439
 		{
 			dataType="Group";
 			side="Independent";
@@ -28561,7 +40016,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1558.835,5.0014391,1356.4191};
+						position[]={1564.194,5.0014391,943.86292};
 					};
 					side="Independent";
 					flags=6;
@@ -28574,7 +40029,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=908;
+					id=3398;
 					type="I_C_Soldier_Para_2_F";
 					class CustomAttributes
 					{
@@ -28605,7 +40060,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1563.7787,5.0014391,1354.2551};
+						position[]={1569.1377,5.0014391,941.6991};
 					};
 					side="Independent";
 					flags=4;
@@ -28617,7 +40072,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=909;
+					id=3399;
 					type="I_C_Soldier_Para_4_F";
 					class CustomAttributes
 					{
@@ -28648,7 +40103,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1554.673,5.0014391,1354.7981};
+						position[]={1560.032,5.0014391,942.24207};
 					};
 					side="Independent";
 					flags=4;
@@ -28661,7 +40116,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1220;
+					id=3400;
 					type="I_C_Soldier_Para_4_F";
 				};
 			};
@@ -28669,7 +40124,7 @@ class Mission
 			{
 				name="GrpSyn_MMG2";
 			};
-			id=907;
+			id=3397;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -28694,7 +40149,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item307
+		class Item440
 		{
 			dataType="Group";
 			side="Independent";
@@ -28706,7 +40161,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1558.859,5.0014391,1345.2571};
+						position[]={1564.218,5.0014391,932.70105};
 					};
 					side="Independent";
 					flags=6;
@@ -28719,7 +40174,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=911;
+					id=3402;
 					type="I_C_Soldier_Para_2_F";
 					class CustomAttributes
 					{
@@ -28750,7 +40205,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1563.8041,5.0014391,1343.093};
+						position[]={1569.1631,5.0014391,930.53699};
 					};
 					side="Independent";
 					flags=4;
@@ -28762,7 +40217,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=912;
+					id=3403;
 					type="I_C_Soldier_Para_5_F";
 					class CustomAttributes
 					{
@@ -28793,7 +40248,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1554.6959,5.0014391,1343.635};
+						position[]={1560.0549,5.0014391,931.07898};
 					};
 					side="Independent";
 					flags=4;
@@ -28806,7 +40261,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1221;
+					id=3404;
 					type="I_C_Soldier_Para_5_F";
 				};
 			};
@@ -28814,7 +40269,7 @@ class Mission
 			{
 				name="GrpSyn_MAT1";
 			};
-			id=910;
+			id=3401;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -28839,7 +40294,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item308
+		class Item441
 		{
 			dataType="Group";
 			side="Independent";
@@ -28851,7 +40306,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1559.0811,5.0014391,1333.7101};
+						position[]={1564.4401,5.0014391,921.15399};
 					};
 					side="Independent";
 					flags=6;
@@ -28864,7 +40319,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=914;
+					id=3406;
 					type="I_C_Soldier_Para_2_F";
 					class CustomAttributes
 					{
@@ -28895,7 +40350,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1564.0248,5.0014391,1331.5461};
+						position[]={1569.3838,5.0014391,918.99017};
 					};
 					side="Independent";
 					flags=4;
@@ -28907,7 +40362,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=915;
+					id=3407;
 					type="I_C_Soldier_Para_5_F";
 					class CustomAttributes
 					{
@@ -28938,7 +40393,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1554.9189,5.0014391,1332.0891};
+						position[]={1560.278,5.0014391,919.53314};
 					};
 					side="Independent";
 					flags=4;
@@ -28951,7 +40406,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1222;
+					id=3408;
 					type="I_C_Soldier_Para_5_F";
 				};
 			};
@@ -28959,7 +40414,7 @@ class Mission
 			{
 				name="GrpSyn_MAT2";
 			};
-			id=913;
+			id=3405;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -28984,7 +40439,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item309
+		class Item442
 		{
 			dataType="Group";
 			side="Independent";
@@ -28996,7 +40451,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1559.0209,5.0014391,1323.0881};
+						position[]={1564.3799,5.0014391,910.5321};
 					};
 					side="Independent";
 					flags=6;
@@ -29009,11 +40464,30 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=917;
+					id=3410;
 					type="I_C_Soldier_Para_2_F";
 					class CustomAttributes
 					{
 						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male01FRE";
+								};
+							};
+						};
+						class Attribute1
 						{
 							property="pitch";
 							expression="_this setpitch _value;";
@@ -29032,7 +40506,7 @@ class Mission
 								};
 							};
 						};
-						nAttributes=1;
+						nAttributes=2;
 					};
 				};
 				class Item1
@@ -29040,7 +40514,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1563.9662,5.0014391,1320.9231};
+						position[]={1569.3252,5.0014391,908.36707};
 					};
 					side="Independent";
 					flags=4;
@@ -29052,11 +40526,30 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=918;
+					id=3411;
 					type="I_C_Soldier_Para_4_F";
 					class CustomAttributes
 					{
 						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male01FRE";
+								};
+							};
+						};
+						class Attribute1
 						{
 							property="pitch";
 							expression="_this setpitch _value;";
@@ -29075,7 +40568,7 @@ class Mission
 								};
 							};
 						};
-						nAttributes=1;
+						nAttributes=2;
 					};
 				};
 			};
@@ -29083,7 +40576,7 @@ class Mission
 			{
 				name="GrpSyn_HMG1";
 			};
-			id=916;
+			id=3409;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -29108,7 +40601,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item310
+		class Item443
 		{
 			dataType="Group";
 			side="Independent";
@@ -29120,7 +40613,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1558.816,5.0014391,1310.2871};
+						position[]={1564.175,5.0014391,897.73108};
 					};
 					side="Independent";
 					flags=6;
@@ -29133,7 +40626,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=920;
+					id=3413;
 					type="I_C_Soldier_Para_2_F";
 					class CustomAttributes
 					{
@@ -29164,7 +40657,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1563.7592,5.0014391,1308.1233};
+						position[]={1569.1182,5.0014391,895.56726};
 					};
 					side="Independent";
 					flags=4;
@@ -29176,7 +40669,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=921;
+					id=3414;
 					type="I_C_Soldier_Para_5_F";
 					class CustomAttributes
 					{
@@ -29207,7 +40700,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1554.6539,5.0014391,1308.666};
+						position[]={1560.0129,5.0014391,896.10999};
 					};
 					side="Independent";
 					flags=4;
@@ -29220,7 +40713,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1223;
+					id=3415;
 					type="I_C_Soldier_Para_5_F";
 				};
 			};
@@ -29228,7 +40721,7 @@ class Mission
 			{
 				name="GrpSyn_HAT1";
 			};
-			id=919;
+			id=3412;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -29253,7 +40746,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item311
+		class Item444
 		{
 			dataType="Group";
 			side="Independent";
@@ -29265,7 +40758,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1559.306,5.0014391,1298.2249};
+						position[]={1564.665,5.0014391,885.66882};
 					};
 					side="Independent";
 					flags=6;
@@ -29278,7 +40771,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=923;
+					id=3417;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
@@ -29309,7 +40802,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1564.2494,5.0014391,1296.0598};
+						position[]={1569.6084,5.0014391,883.50378};
 					};
 					side="Independent";
 					flags=4;
@@ -29321,7 +40814,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=924;
+					id=3418;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
@@ -29352,7 +40845,7 @@ class Mission
 			{
 				name="GrpSyn_MTR1";
 			};
-			id=922;
+			id=3416;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -29377,7 +40870,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item312
+		class Item445
 		{
 			dataType="Group";
 			side="Independent";
@@ -29389,7 +40882,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1559.033,5.0014391,1285.1261};
+						position[]={1564.392,5.0014391,872.57007};
 					};
 					side="Independent";
 					flags=6;
@@ -29402,7 +40895,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=926;
+					id=3420;
 					type="I_C_Soldier_Para_5_F";
 					class CustomAttributes
 					{
@@ -29433,7 +40926,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1563.976,5.0014391,1282.9612};
+						position[]={1569.335,5.0014391,870.40515};
 					};
 					side="Independent";
 					flags=4;
@@ -29445,7 +40938,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=927;
+					id=3421;
 					type="I_C_Soldier_Para_5_F";
 					class CustomAttributes
 					{
@@ -29476,7 +40969,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1554.0341,5.0014391,1283.089};
+						position[]={1559.3931,5.0014391,870.53296};
 					};
 					side="Independent";
 					flags=4;
@@ -29489,7 +40982,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1184;
+					id=3422;
 					type="I_C_Soldier_Para_5_F";
 				};
 			};
@@ -29497,7 +40990,7 @@ class Mission
 			{
 				name="GrpSyn_MSAM1";
 			};
-			id=925;
+			id=3419;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -29522,7 +41015,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item313
+		class Item446
 		{
 			dataType="Group";
 			side="Independent";
@@ -29534,7 +41027,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1559.7533,5.0014391,1272.1184};
+						position[]={1565.1123,5.0014391,859.56238};
 					};
 					side="Independent";
 					flags=6;
@@ -29547,7 +41040,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=929;
+					id=3424;
 					type="I_C_Soldier_Para_5_F";
 					class CustomAttributes
 					{
@@ -29578,7 +41071,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1564.6967,5.0014391,1269.9534};
+						position[]={1570.0557,5.0014391,857.39734};
 					};
 					side="Independent";
 					flags=4;
@@ -29590,7 +41083,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=930;
+					id=3425;
 					type="I_C_Soldier_Para_5_F";
 					class CustomAttributes
 					{
@@ -29621,7 +41114,7 @@ class Mission
 			{
 				name="GrpSyn_HSAM1";
 			};
-			id=928;
+			id=3423;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -29646,7 +41139,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item314
+		class Item447
 		{
 			dataType="Group";
 			side="Independent";
@@ -29658,7 +41151,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1559.8353,5.0014391,1261.8909};
+						position[]={1565.1943,5.0014391,849.33484};
 					};
 					side="Independent";
 					flags=6;
@@ -29671,11 +41164,30 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=932;
+					id=3427;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
 						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male02FRE";
+								};
+							};
+						};
+						class Attribute1
 						{
 							property="pitch";
 							expression="_this setpitch _value;";
@@ -29694,7 +41206,7 @@ class Mission
 								};
 							};
 						};
-						nAttributes=1;
+						nAttributes=2;
 					};
 				};
 				class Item1
@@ -29702,7 +41214,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1564.7787,5.0014391,1259.7258};
+						position[]={1570.1377,5.0014391,847.1698};
 					};
 					side="Independent";
 					flags=4;
@@ -29714,11 +41226,30 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=933;
+					id=3428;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
 						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male02FRE";
+								};
+							};
+						};
+						class Attribute1
 						{
 							property="pitch";
 							expression="_this setpitch _value;";
@@ -29737,7 +41268,7 @@ class Mission
 								};
 							};
 						};
-						nAttributes=1;
+						nAttributes=2;
 					};
 				};
 			};
@@ -29745,7 +41276,7 @@ class Mission
 			{
 				name="GrpSyn_ST1";
 			};
-			id=931;
+			id=3426;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -29770,7 +41301,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item315
+		class Item448
 		{
 			dataType="Group";
 			side="Independent";
@@ -29782,7 +41313,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1560.3763,5.0014391,1249.842};
+						position[]={1565.7354,5.0014391,837.28601};
 					};
 					side="Independent";
 					flags=6;
@@ -29795,7 +41326,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=935;
+					id=3430;
 					type="I_C_Soldier_Para_8_F";
 					class CustomAttributes
 					{
@@ -29826,7 +41357,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1565.3197,5.0014391,1247.677};
+						position[]={1570.6787,5.0014391,835.12097};
 					};
 					side="Independent";
 					flags=4;
@@ -29838,7 +41369,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=936;
+					id=3431;
 					type="I_C_Soldier_Para_8_F";
 					class CustomAttributes
 					{
@@ -29869,7 +41400,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1554.9447,5.0014391,1248.1292};
+						position[]={1560.3037,5.0014391,835.57312};
 					};
 					side="Independent";
 					flags=4;
@@ -29881,7 +41412,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=937;
+					id=3432;
 					type="I_C_Soldier_Para_8_F";
 					class CustomAttributes
 					{
@@ -29912,7 +41443,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1570.2924,5.0014391,1245.7551};
+						position[]={1575.6514,5.0014391,833.1991};
 					};
 					side="Independent";
 					flags=4;
@@ -29924,7 +41455,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=938;
+					id=3433;
 					type="I_C_Soldier_Para_8_F";
 					class CustomAttributes
 					{
@@ -29955,7 +41486,7 @@ class Mission
 			{
 				name="GrpSyn_ENG1";
 			};
-			id=934;
+			id=3429;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -29980,7 +41511,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item316
+		class Item449
 		{
 			dataType="Group";
 			side="Independent";
@@ -29992,7 +41523,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1559.641,5.0014391,1225.605};
+						position[]={1565,5.0014391,813.05005};
 					};
 					side="Independent";
 					flags=6;
@@ -30005,7 +41536,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=940;
+					id=3435;
 					type="I_C_Helipilot_F";
 					class CustomAttributes
 					{
@@ -30036,7 +41567,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1559.641,5.0014391,1225.605};
+						position[]={1565,5.0014391,813.05005};
 					};
 					side="Independent";
 					flags=4;
@@ -30049,7 +41580,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=941;
+					id=3436;
 					type="I_C_Helipilot_F";
 					class CustomAttributes
 					{
@@ -30092,8 +41623,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=940;
-						item1=1027;
+						item0=3435;
+						item1=3478;
 						class CustomData
 						{
 							role=1;
@@ -30102,8 +41633,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=941;
-						item1=1027;
+						item0=3436;
+						item1=3478;
 						class CustomData
 						{
 							role=2;
@@ -30112,8 +41643,7 @@ class Mission
 					};
 				};
 			};
-			id=939;
-			atlOffset=0.33195591;
+			id=3434;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -30138,7 +41668,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item317
+		class Item450
 		{
 			dataType="Group";
 			side="Independent";
@@ -30150,7 +41680,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1379.3519,5.0014391,1284.8792};
+						position[]={1384.7111,5.0014391,872.323};
 					};
 					side="Independent";
 					flags=6;
@@ -30163,7 +41693,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=944;
+					id=3438;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
@@ -30194,7 +41724,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1379.3519,5.0014391,1284.8792};
+						position[]={1384.7111,5.0014391,872.323};
 					};
 					side="Independent";
 					flags=4;
@@ -30206,7 +41736,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=945;
+					id=3439;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
@@ -30249,8 +41779,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=944;
-						item1=946;
+						item0=3438;
+						item1=3440;
 						class CustomData
 						{
 							role=2;
@@ -30260,8 +41790,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=945;
-						item1=946;
+						item0=3439;
+						item1=3440;
 						class CustomData
 						{
 							role=1;
@@ -30269,7 +41799,7 @@ class Mission
 					};
 				};
 			};
-			id=943;
+			id=3437;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -30287,19 +41817,19 @@ class Mission
 									"STRING"
 								};
 							};
-							value="Syndikat IFV1 -";
+							value="Syndikat TECH1 -";
 						};
 					};
 				};
 				nAttributes=1;
 			};
 		};
-		class Item318
+		class Item451
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1379.3519,7.1644082,1284.8704};
+				position[]={1384.7111,7.1644082,872.31433};
 			};
 			side="Independent";
 			flags=6;
@@ -30310,10 +41840,10 @@ class Mission
 				name="VehSyn_IFV1";
 				textures="Guerilla_09";
 			};
-			id=946;
+			id=3440;
 			type="B_G_Offroad_01_armed_F";
 		};
-		class Item319
+		class Item452
 		{
 			dataType="Group";
 			side="Independent";
@@ -30325,7 +41855,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1420.1664,5.0014391,1287.9719};
+						position[]={1425.525,5.0014391,875.41602};
 					};
 					side="Independent";
 					flags=6;
@@ -30338,7 +41868,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=948;
+					id=3442;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
@@ -30369,7 +41899,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1420.1664,5.0014391,1287.9719};
+						position[]={1425.525,5.0014391,875.41602};
 					};
 					side="Independent";
 					flags=4;
@@ -30381,7 +41911,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=949;
+					id=3443;
 					type="I_C_Soldier_Para_1_F";
 					class CustomAttributes
 					{
@@ -30424,8 +41954,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=948;
-						item1=950;
+						item0=3442;
+						item1=3444;
 						class CustomData
 						{
 							role=2;
@@ -30435,8 +41965,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=949;
-						item1=950;
+						item0=3443;
+						item1=3444;
 						class CustomData
 						{
 							role=1;
@@ -30444,7 +41974,7 @@ class Mission
 					};
 				};
 			};
-			id=947;
+			id=3441;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -30462,19 +41992,19 @@ class Mission
 									"STRING"
 								};
 							};
-							value="Syndikat IFV2 -";
+							value="Syndikat TECH2 -";
 						};
 					};
 				};
 				nAttributes=1;
 			};
 		};
-		class Item320
+		class Item453
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1420.1664,7.1644082,1287.9631};
+				position[]={1425.525,7.1644082,875.40735};
 			};
 			side="Independent";
 			flags=6;
@@ -30485,15 +42015,15 @@ class Mission
 				name="VehSyn_IFV2";
 				textures="Guerilla_09";
 			};
-			id=950;
+			id=3444;
 			type="B_G_Offroad_01_armed_F";
 		};
-		class Item321
+		class Item454
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1367.5658,6.5695963,1372.9875};
+				position[]={1372.9248,6.5695963,960.43152};
 			};
 			side="Empty";
 			flags=4;
@@ -30504,15 +42034,15 @@ class Mission
 				name="VehSyn_CAR1";
 				textures="Olive";
 			};
-			id=951;
+			id=3445;
 			type="I_C_Offroad_02_unarmed_F";
 		};
-		class Item322
+		class Item455
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1366.2035,6.5695963,1345.7668};
+				position[]={1371.5625,6.5695963,933.21082};
 			};
 			side="Empty";
 			flags=4;
@@ -30523,15 +42053,15 @@ class Mission
 				name="VehSyn_CAR2";
 				textures="Olive";
 			};
-			id=952;
+			id=3446;
 			type="I_C_Offroad_02_unarmed_F";
 		};
-		class Item323
+		class Item456
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1418.0883,6.8716264,1395.2258};
+				position[]={1423.4473,6.8715067,982.6698};
 			};
 			side="Empty";
 			flags=4;
@@ -30542,16 +42072,15 @@ class Mission
 				name="VehSyn_TR1";
 				textures="Olive";
 			};
-			id=953;
+			id=3447;
 			type="I_C_Van_01_transport_F";
-			atlOffset=0.00011968613;
 		};
-		class Item324
+		class Item457
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1425.2494,6.8716264,1389.2473};
+				position[]={1430.6084,6.8715067,976.69128};
 			};
 			side="Empty";
 			flags=4;
@@ -30562,16 +42091,15 @@ class Mission
 				name="VehSyn_TR2";
 				textures="Olive";
 			};
-			id=954;
+			id=3448;
 			type="I_C_Van_01_transport_F";
-			atlOffset=0.00011968613;
 		};
-		class Item325
+		class Item458
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1455.6927,6.8716264,1395.2034};
+				position[]={1461.0518,6.8715067,982.64734};
 			};
 			side="Empty";
 			flags=4;
@@ -30582,16 +42110,15 @@ class Mission
 				name="VehSyn_TR3";
 				textures="Olive";
 			};
-			id=955;
+			id=3449;
 			type="I_C_Van_01_transport_F";
-			atlOffset=0.00011968613;
 		};
-		class Item326
+		class Item459
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1463.8392,6.8716264,1388.677};
+				position[]={1469.1982,6.8715067,976.12097};
 			};
 			side="Empty";
 			flags=4;
@@ -30602,16 +42129,15 @@ class Mission
 				name="VehSyn_TR4";
 				textures="Olive";
 			};
-			id=956;
+			id=3450;
 			type="I_C_Van_01_transport_F";
-			atlOffset=0.00011968613;
 		};
-		class Item327
+		class Item460
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1499.974,6.8716264,1393.5471};
+				position[]={1505.333,6.8715067,980.99109};
 			};
 			side="Empty";
 			flags=4;
@@ -30622,16 +42148,15 @@ class Mission
 				name="VehSyn_TR5";
 				textures="Olive";
 			};
-			id=957;
+			id=3451;
 			type="I_C_Van_01_transport_F";
-			atlOffset=0.00011968613;
 		};
-		class Item328
+		class Item461
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1516.6342,6.8716264,1389.5872};
+				position[]={1521.9932,6.8715067,977.03113};
 			};
 			side="Empty";
 			flags=4;
@@ -30642,16 +42167,15 @@ class Mission
 				name="VehSyn_TR6";
 				textures="Olive";
 			};
-			id=958;
+			id=3452;
 			type="I_C_Van_01_transport_F";
-			atlOffset=0.00011968613;
 		};
-		class Item329
+		class Item462
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1574.7318,6.5695963,1367.6516};
+				position[]={1580.0908,6.5695963,955.09558};
 			};
 			side="Empty";
 			flags=4;
@@ -30662,15 +42186,15 @@ class Mission
 				name="VehSyn_CAR3";
 				textures="Olive";
 			};
-			id=959;
+			id=3453;
 			type="I_C_Offroad_02_unarmed_F";
 		};
-		class Item330
+		class Item463
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1573.8197,6.5695963,1342.1731};
+				position[]={1579.1787,6.5695963,929.61707};
 			};
 			side="Empty";
 			flags=4;
@@ -30681,15 +42205,15 @@ class Mission
 				name="VehSyn_CAR4";
 				textures="Olive";
 			};
-			id=960;
+			id=3454;
 			type="I_C_Offroad_02_unarmed_F";
 		};
-		class Item331
+		class Item464
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1507.12,5.8924227,1374.978};
+				position[]={1512.479,5.8924227,962.422};
 			};
 			side="Empty";
 			flags=4;
@@ -30699,7 +42223,7 @@ class Mission
 				init="[""crate_med"",this,""ind_c_f""] call f_fnc_assignGear";
 				name="CrateSyn_C";
 			};
-			id=961;
+			id=3455;
 			type="IG_supplyCrate_F";
 			class CustomAttributes
 			{
@@ -30725,12 +42249,12 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item332
+		class Item465
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1465.968,5.8924227,1375.243};
+				position[]={1471.327,5.8924227,962.68689};
 			};
 			side="Empty";
 			flags=4;
@@ -30740,7 +42264,7 @@ class Mission
 				init="[""crate_med"",this,""ind_c_f""] call f_fnc_assignGear";
 				name="CrateSyn_B";
 			};
-			id=962;
+			id=3456;
 			type="IG_supplyCrate_F";
 			class CustomAttributes
 			{
@@ -30766,12 +42290,12 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item333
+		class Item466
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1425.147,5.8924227,1375.54};
+				position[]={1430.506,5.8924227,962.98401};
 			};
 			side="Empty";
 			flags=4;
@@ -30781,7 +42305,7 @@ class Mission
 				init="[""crate_med"",this,""ind_c_f""] call f_fnc_assignGear";
 				name="CrateSyn_A";
 			};
-			id=963;
+			id=3457;
 			type="IG_supplyCrate_F";
 			class CustomAttributes
 			{
@@ -30807,14 +42331,14 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item334
+		class Item467
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1348.1381,5,1369.7581};
+				position[]={1353.4971,5,957.20203};
 			};
-			id=964;
+			id=3458;
 			type="SupportRequester";
 			class CustomAttributes
 			{
@@ -30954,7 +42478,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item335
+		class Item468
 		{
 			dataType="Group";
 			side="Independent";
@@ -30966,14 +42490,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1350.14,5.0014391,1363.6685};
+						position[]={1355.499,5.0014391,951.112};
 					};
 					side="Independent";
 					flags=6;
 					class Attributes
 					{
 					};
-					id=966;
+					id=3460;
 					type="I_helipilot_F";
 					class CustomAttributes
 					{
@@ -31004,14 +42528,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1350.14,5.0014391,1363.6685};
+						position[]={1355.499,5.0014391,951.112};
 					};
 					side="Independent";
 					flags=4;
 					class Attributes
 					{
 					};
-					id=967;
+					id=3461;
 					type="I_helipilot_F";
 					class CustomAttributes
 					{
@@ -31053,8 +42577,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=966;
-						item1=968;
+						item0=3460;
+						item1=3462;
 						class CustomData
 						{
 							role=1;
@@ -31063,8 +42587,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=967;
-						item1=968;
+						item0=3461;
+						item1=3462;
 						class CustomData
 						{
 							role=2;
@@ -31073,14 +42597,14 @@ class Mission
 					};
 				};
 			};
-			id=965;
+			id=3459;
 		};
-		class Item336
+		class Item469
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1350.14,6.5310755,1363.6184};
+				position[]={1355.499,6.5310755,951.06201};
 			};
 			side="Independent";
 			flags=6;
@@ -31090,10 +42614,10 @@ class Mission
 				textures="Green";
 				receiveRemoteTargets=1;
 			};
-			id=968;
+			id=3462;
 			type="I_Heli_light_03_dynamicLoadout_F";
 		};
-		class Item337
+		class Item470
 		{
 			dataType="Group";
 			side="Independent";
@@ -31105,14 +42629,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1346.0267,5.0014391,1363.6892};
+						position[]={1351.3857,5.0014391,951.13318};
 					};
 					side="Independent";
 					flags=6;
 					class Attributes
 					{
 					};
-					id=970;
+					id=3464;
 					type="I_soldier_F";
 					class CustomAttributes
 					{
@@ -31154,8 +42678,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=970;
-						item1=971;
+						item0=3464;
+						item1=3465;
 						class CustomData
 						{
 							role=2;
@@ -31164,14 +42688,14 @@ class Mission
 					};
 				};
 			};
-			id=969;
+			id=3463;
 		};
-		class Item338
+		class Item471
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1346.0267,5.7216258,1363.6389};
+				position[]={1351.3857,5.7216258,951.08276};
 			};
 			side="Independent";
 			flags=6;
@@ -31179,17 +42703,17 @@ class Mission
 			{
 				skill=0.60000002;
 			};
-			id=971;
+			id=3465;
 			type="I_Mortar_01_F";
 		};
-		class Item339
+		class Item472
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1350.3256,5,1367.3372};
+				position[]={1355.6846,5,954.78113};
 			};
-			id=972;
+			id=3466;
 			type="SupportProvider_Virtual_CAS_Heli";
 			class CustomAttributes
 			{
@@ -31272,24 +42796,24 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item340
+		class Item473
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1346.0433,5,1367.4338};
+				position[]={1351.4023,5,954.87781};
 			};
-			id=973;
+			id=3467;
 			type="SupportProvider_Artillery";
 		};
-		class Item341
+		class Item474
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1348.4252,5,1341.1448};
+				position[]={1353.7842,5,928.58875};
 			};
-			id=974;
+			id=3468;
 			type="SupportRequester";
 			class CustomAttributes
 			{
@@ -31429,7 +42953,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item342
+		class Item475
 		{
 			dataType="Group";
 			side="Independent";
@@ -31441,14 +42965,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1350.4271,5.0014391,1335.0552};
+						position[]={1355.7861,5.0014391,922.49921};
 					};
 					side="Independent";
 					flags=6;
 					class Attributes
 					{
 					};
-					id=976;
+					id=3470;
 					type="I_helipilot_F";
 					class CustomAttributes
 					{
@@ -31479,14 +43003,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1350.4271,5.0014391,1335.0552};
+						position[]={1355.7861,5.0014391,922.49921};
 					};
 					side="Independent";
 					flags=4;
 					class Attributes
 					{
 					};
-					id=977;
+					id=3471;
 					type="I_helipilot_F";
 					class CustomAttributes
 					{
@@ -31528,8 +43052,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=976;
-						item1=978;
+						item0=3470;
+						item1=3472;
 						class CustomData
 						{
 							role=1;
@@ -31538,8 +43062,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=977;
-						item1=978;
+						item0=3471;
+						item1=3472;
 						class CustomData
 						{
 							role=2;
@@ -31548,14 +43072,14 @@ class Mission
 					};
 				};
 			};
-			id=975;
+			id=3469;
 		};
-		class Item343
+		class Item476
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1350.4271,6.5310755,1335.0051};
+				position[]={1355.7861,6.5310755,922.44916};
 			};
 			side="Independent";
 			flags=6;
@@ -31565,10 +43089,10 @@ class Mission
 				textures="Green";
 				receiveRemoteTargets=1;
 			};
-			id=978;
+			id=3472;
 			type="I_Heli_light_03_dynamicLoadout_F";
 		};
-		class Item344
+		class Item477
 		{
 			dataType="Group";
 			side="Independent";
@@ -31580,14 +43104,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1346.3138,5.0014391,1335.0759};
+						position[]={1351.6729,5.0014391,922.51996};
 					};
 					side="Independent";
 					flags=6;
 					class Attributes
 					{
 					};
-					id=980;
+					id=3474;
 					type="I_soldier_F";
 					class CustomAttributes
 					{
@@ -31629,8 +43153,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=980;
-						item1=981;
+						item0=3474;
+						item1=3475;
 						class CustomData
 						{
 							role=2;
@@ -31639,14 +43163,14 @@ class Mission
 					};
 				};
 			};
-			id=979;
+			id=3473;
 		};
-		class Item345
+		class Item478
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1346.3138,5.7216258,1335.0256};
+				position[]={1351.6729,5.7216258,922.46954};
 			};
 			side="Independent";
 			flags=6;
@@ -31654,17 +43178,17 @@ class Mission
 			{
 				skill=0.60000002;
 			};
-			id=981;
+			id=3475;
 			type="I_Mortar_01_F";
 		};
-		class Item346
+		class Item479
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1350.6117,5,1338.7239};
+				position[]={1355.9707,5,926.16785};
 			};
-			id=982;
+			id=3476;
 			type="SupportProvider_Virtual_CAS_Heli";
 			class CustomAttributes
 			{
@@ -31747,25 +43271,25 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item347
+		class Item480
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1346.3304,5,1338.8206};
+				position[]={1351.6895,5,926.26453};
 			};
-			id=983;
+			id=3477;
 			type="SupportProvider_Artillery";
 		};
-		class Item348
+		class Item481
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1559.641,6.8630314,1225.556};
+				position[]={1565,6.5310755,813};
 			};
 			side="Independent";
-			flags=2;
+			flags=6;
 			class Attributes
 			{
 				skill=0.60000002;
@@ -31775,11 +43299,10 @@ class Mission
 				receiveRemoteTargets=1;
 				pylons=";;";
 			};
-			id=1027;
+			id=3478;
 			type="I_Heli_light_03_dynamicLoadout_F";
-			atlOffset=0.33195591;
 		};
-		class Item349
+		class Item482
 		{
 			dataType="Group";
 			side="West";
@@ -31791,7 +43314,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={489.91336,5.0014391,1044.3853};
+						position[]={488.63699,5.0014391,525.81097};
 					};
 					side="West";
 					flags=7;
@@ -31804,7 +43327,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1038;
+					id=3480;
 					type="B_GEN_Commander_F";
 					class CustomAttributes
 					{
@@ -31847,8 +43370,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=1038;
-						item1=1088;
+						item0=3480;
+						item1=3509;
 						class CustomData
 						{
 							role=1;
@@ -31856,7 +43379,7 @@ class Mission
 					};
 				};
 			};
-			id=1037;
+			id=3479;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -31881,7 +43404,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item350
+		class Item483
 		{
 			dataType="Group";
 			side="West";
@@ -31893,7 +43416,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={490.23773,5.0014391,1022.6599};
+						position[]={488.961,5.0014391,504.086};
 					};
 					side="West";
 					flags=7;
@@ -31906,7 +43429,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1040;
+					id=3482;
 					type="B_GEN_Commander_F";
 					class CustomAttributes
 					{
@@ -31949,8 +43472,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=1040;
-						item1=1089;
+						item0=3482;
+						item1=3510;
 						class CustomData
 						{
 							role=1;
@@ -31958,7 +43481,7 @@ class Mission
 					};
 				};
 			};
-			id=1039;
+			id=3481;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -31983,7 +43506,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item351
+		class Item484
 		{
 			dataType="Group";
 			side="West";
@@ -31995,7 +43518,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={509.84177,5.0014391,1044.8337};
+						position[]={508.56494,5.0014391,526.26001};
 					};
 					side="West";
 					flags=6;
@@ -32008,7 +43531,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1067;
+					id=3484;
 					type="B_GEN_Soldier_F";
 					class CustomAttributes
 					{
@@ -32039,7 +43562,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={509.84177,5.0014391,1044.8337};
+						position[]={508.56494,5.0014391,526.26001};
 					};
 					side="West";
 					flags=4;
@@ -32052,7 +43575,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1235;
+					id=3485;
 					type="B_GEN_Soldier_F";
 					class CustomAttributes
 					{
@@ -32083,7 +43606,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={514.65173,5.0014391,1039.97};
+						position[]={513.375,5.0014391,521.39624};
 					};
 					side="West";
 					flags=4;
@@ -32096,7 +43619,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1237;
+					id=3486;
 					type="B_GEN_Soldier_F";
 					class CustomAttributes
 					{
@@ -32127,7 +43650,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={514.65173,5.0014391,1039.97};
+						position[]={513.375,5.0014391,521.39624};
 					};
 					side="West";
 					flags=4;
@@ -32139,7 +43662,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1238;
+					id=3487;
 					type="B_GEN_Soldier_F";
 					class CustomAttributes
 					{
@@ -32182,8 +43705,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=1067;
-						item1=1090;
+						item0=3484;
+						item1=3511;
 						class CustomData
 						{
 							role=2;
@@ -32193,8 +43716,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=1235;
-						item1=1090;
+						item0=3485;
+						item1=3511;
 						class CustomData
 						{
 							role=1;
@@ -32203,8 +43726,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=1237;
-						item1=1091;
+						item0=3486;
+						item1=3512;
 						class CustomData
 						{
 							role=2;
@@ -32214,8 +43737,8 @@ class Mission
 					class Item3
 					{
 						linkID=3;
-						item0=1238;
-						item1=1091;
+						item0=3487;
+						item1=3512;
 						class CustomData
 						{
 							role=1;
@@ -32223,7 +43746,7 @@ class Mission
 					};
 				};
 			};
-			id=1041;
+			id=3483;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -32248,7 +43771,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item352
+		class Item485
 		{
 			dataType="Group";
 			side="West";
@@ -32260,7 +43783,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={510.1658,5.0014391,1021.7027};
+						position[]={508.88901,5.0014391,503.129};
 					};
 					side="West";
 					flags=6;
@@ -32273,7 +43796,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1070;
+					id=3489;
 					type="B_GEN_Soldier_F";
 					class CustomAttributes
 					{
@@ -32304,7 +43827,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={510.1658,5.0014391,1021.7027};
+						position[]={508.88901,5.0014391,503.129};
 					};
 					side="West";
 					flags=4;
@@ -32317,7 +43840,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1071;
+					id=3490;
 					type="B_GEN_Soldier_F";
 					class CustomAttributes
 					{
@@ -32348,7 +43871,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={510.1658,5.0014391,1021.7027};
+						position[]={508.88901,5.0014391,503.129};
 					};
 					side="West";
 					flags=4;
@@ -32361,7 +43884,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1072;
+					id=3491;
 					type="B_GEN_Soldier_F";
 					class CustomAttributes
 					{
@@ -32392,7 +43915,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={510.1658,5.0014391,1021.7027};
+						position[]={508.88901,5.0014391,503.129};
 					};
 					side="West";
 					flags=4;
@@ -32404,7 +43927,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1073;
+					id=3492;
 					type="B_GEN_Soldier_F";
 					class CustomAttributes
 					{
@@ -32447,8 +43970,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=1070;
-						item1=1092;
+						item0=3489;
+						item1=3513;
 						class CustomData
 						{
 							role=3;
@@ -32458,8 +43981,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=1071;
-						item1=1092;
+						item0=3490;
+						item1=3513;
 						class CustomData
 						{
 							role=2;
@@ -32469,8 +43992,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=1072;
-						item1=1092;
+						item0=3491;
+						item1=3513;
 						class CustomData
 						{
 							role=2;
@@ -32480,8 +44003,8 @@ class Mission
 					class Item3
 					{
 						linkID=3;
-						item0=1073;
-						item1=1092;
+						item0=3492;
+						item1=3513;
 						class CustomData
 						{
 							role=1;
@@ -32489,7 +44012,7 @@ class Mission
 					};
 				};
 			};
-			id=1049;
+			id=3488;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -32514,7 +44037,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item353
+		class Item486
 		{
 			dataType="Group";
 			side="West";
@@ -32526,7 +44049,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={510.59879,5.0014391,999.65369};
+						position[]={509.32199,5.0014391,481.07999};
 					};
 					side="West";
 					flags=6;
@@ -32539,7 +44062,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1074;
+					id=3494;
 					type="B_GEN_Soldier_F";
 					class CustomAttributes
 					{
@@ -32570,7 +44093,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={510.59879,5.0014391,999.65369};
+						position[]={509.32199,5.0014391,481.07999};
 					};
 					side="West";
 					flags=4;
@@ -32583,7 +44106,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1075;
+					id=3495;
 					type="B_GEN_Soldier_F";
 					class CustomAttributes
 					{
@@ -32614,7 +44137,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={510.59879,5.0014391,999.65369};
+						position[]={509.32199,5.0014391,481.07999};
 					};
 					side="West";
 					flags=4;
@@ -32627,7 +44150,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1076;
+					id=3496;
 					type="B_GEN_Soldier_F";
 					class CustomAttributes
 					{
@@ -32658,7 +44181,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={510.59879,5.0014391,999.65369};
+						position[]={509.32199,5.0014391,481.07999};
 					};
 					side="West";
 					flags=4;
@@ -32670,7 +44193,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1077;
+					id=3497;
 					type="B_GEN_Soldier_F";
 					class CustomAttributes
 					{
@@ -32713,8 +44236,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=1074;
-						item1=1093;
+						item0=3494;
+						item1=3514;
 						class CustomData
 						{
 							role=3;
@@ -32724,8 +44247,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=1075;
-						item1=1093;
+						item0=3495;
+						item1=3514;
 						class CustomData
 						{
 							role=2;
@@ -32735,8 +44258,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=1076;
-						item1=1093;
+						item0=3496;
+						item1=3514;
 						class CustomData
 						{
 							role=2;
@@ -32746,8 +44269,8 @@ class Mission
 					class Item3
 					{
 						linkID=3;
-						item0=1077;
-						item1=1093;
+						item0=3497;
+						item1=3514;
 						class CustomData
 						{
 							role=1;
@@ -32755,7 +44278,7 @@ class Mission
 					};
 				};
 			};
-			id=1054;
+			id=3493;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -32780,7 +44303,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item354
+		class Item487
 		{
 			dataType="Group";
 			side="West";
@@ -32792,7 +44315,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={510.27676,5.0014391,976.62372};
+						position[]={509,5.0014391,458.04999};
 					};
 					side="West";
 					flags=6;
@@ -32805,7 +44328,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1078;
+					id=3499;
 					type="B_GEN_Soldier_F";
 					class CustomAttributes
 					{
@@ -32836,7 +44359,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={510.27676,5.0014391,976.62372};
+						position[]={509,5.0014391,458.04999};
 					};
 					side="West";
 					flags=4;
@@ -32849,7 +44372,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1079;
+					id=3500;
 					type="B_GEN_Soldier_F";
 					class CustomAttributes
 					{
@@ -32880,7 +44403,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={510.27676,5.0014391,976.62372};
+						position[]={509,5.0014391,458.04999};
 					};
 					side="West";
 					flags=4;
@@ -32893,7 +44416,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1080;
+					id=3501;
 					type="B_GEN_Soldier_F";
 					class CustomAttributes
 					{
@@ -32924,7 +44447,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={510.27676,5.0014391,976.62372};
+						position[]={509,5.0014391,458.04999};
 					};
 					side="West";
 					flags=4;
@@ -32936,7 +44459,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1081;
+					id=3502;
 					type="B_GEN_Soldier_F";
 					class CustomAttributes
 					{
@@ -32979,8 +44502,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=1078;
-						item1=1098;
+						item0=3499;
+						item1=3515;
 						class CustomData
 						{
 							role=3;
@@ -32990,8 +44513,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=1079;
-						item1=1098;
+						item0=3500;
+						item1=3515;
 						class CustomData
 						{
 							role=3;
@@ -33001,8 +44524,8 @@ class Mission
 					class Item2
 					{
 						linkID=2;
-						item0=1080;
-						item1=1098;
+						item0=3501;
+						item1=3515;
 						class CustomData
 						{
 							role=3;
@@ -33012,8 +44535,8 @@ class Mission
 					class Item3
 					{
 						linkID=3;
-						item0=1081;
-						item1=1098;
+						item0=3502;
+						item1=3515;
 						class CustomData
 						{
 							role=1;
@@ -33021,7 +44544,7 @@ class Mission
 					};
 				};
 			};
-			id=1059;
+			id=3498;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -33046,7 +44569,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item355
+		class Item488
 		{
 			dataType="Group";
 			side="West";
@@ -33058,7 +44581,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={491.44461,5.0014391,999.80695};
+						position[]={490.168,5.0014391,481.233};
 					};
 					side="West";
 					flags=6;
@@ -33071,11 +44594,30 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1082;
+					id=3504;
 					type="B_GEN_Soldier_F";
 					class CustomAttributes
 					{
 						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male01ENGFRE";
+								};
+							};
+						};
+						class Attribute1
 						{
 							property="pitch";
 							expression="_this setpitch _value;";
@@ -33094,7 +44636,7 @@ class Mission
 								};
 							};
 						};
-						nAttributes=1;
+						nAttributes=2;
 					};
 				};
 			};
@@ -33102,7 +44644,7 @@ class Mission
 			{
 				name="GrpGEN_MK";
 			};
-			id=1064;
+			id=3503;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -33120,14 +44662,14 @@ class Mission
 									"STRING"
 								};
 							};
-							value="Gendarmerie MK -";
+							value="Gendarmerie Marksman -";
 						};
 					};
 				};
 				nAttributes=1;
 			};
 		};
-		class Item356
+		class Item489
 		{
 			dataType="Group";
 			side="West";
@@ -33139,7 +44681,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={491.17267,5.0014391,976.23016};
+						position[]={489.896,5.0014391,457.65598};
 					};
 					side="West";
 					flags=7;
@@ -33152,7 +44694,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1084;
+					id=3506;
 					type="B_GEN_Commander_F";
 					class CustomAttributes
 					{
@@ -33183,7 +44725,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={491.17267,5.0014391,976.23016};
+						position[]={489.896,5.0014391,457.65598};
 					};
 					side="West";
 					flags=5;
@@ -33196,7 +44738,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1086;
+					id=3507;
 					type="B_GEN_Commander_F";
 					class CustomAttributes
 					{
@@ -33239,8 +44781,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=1084;
-						item1=1087;
+						item0=3506;
+						item1=3508;
 						class CustomData
 						{
 							role=1;
@@ -33249,8 +44791,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=1086;
-						item1=1087;
+						item0=3507;
+						item1=3508;
 						class CustomData
 						{
 							role=2;
@@ -33259,7 +44801,7 @@ class Mission
 					};
 				};
 			};
-			id=1083;
+			id=3505;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -33284,12 +44826,12 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item357
+		class Item490
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={491.17273,5.6047058,975.20013};
+				position[]={489.89606,5.6047058,456.62592};
 			};
 			side="West";
 			flags=6;
@@ -33299,15 +44841,15 @@ class Mission
 				name="VehGEN_TH1";
 				textures="BlueLine";
 			};
-			id=1087;
+			id=3508;
 			type="C_Heli_Light_01_civil_F";
 		};
-		class Item358
+		class Item491
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={489.91336,6.6115026,1044.366};
+				position[]={488.63699,6.6115026,525.79175};
 			};
 			side="West";
 			flags=6;
@@ -33316,15 +44858,15 @@ class Mission
 				init="[""v_car"",this] call f_fnc_assignGear";
 				name="VehGEN_CAR1";
 			};
-			id=1088;
+			id=3509;
 			type="B_GEN_Offroad_01_gen_F";
 		};
-		class Item359
+		class Item492
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={490.23773,6.6115026,1022.6406};
+				position[]={488.961,6.6115026,504.06677};
 			};
 			side="West";
 			flags=6;
@@ -33333,15 +44875,15 @@ class Mission
 				init="[""v_car"",this] call f_fnc_assignGear";
 				name="VehGEN_CAR2";
 			};
-			id=1089;
+			id=3510;
 			type="B_GEN_Offroad_01_gen_F";
 		};
-		class Item360
+		class Item493
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={509.84177,6.6115026,1044.8145};
+				position[]={508.56494,6.6115026,526.24072};
 			};
 			side="West";
 			flags=4;
@@ -33350,15 +44892,15 @@ class Mission
 				init="[""v_car"",this] call f_fnc_assignGear";
 				name="VehGEN_CAR3";
 			};
-			id=1090;
+			id=3511;
 			type="B_GEN_Offroad_01_gen_F";
 		};
-		class Item361
+		class Item494
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={514.65173,6.6115026,1039.9507};
+				position[]={513.375,6.6115026,521.37695};
 			};
 			side="West";
 			flags=4;
@@ -33367,15 +44909,15 @@ class Mission
 				init="[""v_car"",this] call f_fnc_assignGear";
 				name="VehGEN_CAR4";
 			};
-			id=1091;
+			id=3512;
 			type="B_GEN_Offroad_01_gen_F";
 		};
-		class Item362
+		class Item495
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={510.1658,6.6115026,1021.6835};
+				position[]={508.88901,6.6115026,503.10977};
 			};
 			side="West";
 			flags=4;
@@ -33384,15 +44926,15 @@ class Mission
 				init="[""v_car"",this] call f_fnc_assignGear";
 				name="VehGEN_CAR5";
 			};
-			id=1092;
+			id=3513;
 			type="B_GEN_Offroad_01_gen_F";
 		};
-		class Item363
+		class Item496
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={510.59879,6.6115026,999.63446};
+				position[]={509.32199,6.6115026,481.06076};
 			};
 			side="West";
 			flags=4;
@@ -33401,15 +44943,15 @@ class Mission
 				init="[""v_car"",this] call f_fnc_assignGear";
 				name="VehGEN_CAR6";
 			};
-			id=1093;
+			id=3514;
 			type="B_GEN_Offroad_01_gen_F";
 		};
-		class Item364
+		class Item497
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={510.27676,6.5964622,976.57373};
+				position[]={509,6.5964622,458};
 			};
 			side="West";
 			flags=4;
@@ -33419,140 +44961,130 @@ class Mission
 				name="VehGEN_CAR7";
 				textures="Black";
 			};
-			id=1098;
+			id=3515;
 			type="C_SUV_01_F";
 		};
-		class Item365
+		class Item498
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={473.59708,0,776.08887};
+				position[]={467.05713,5,967.90967};
 			};
 			name="F3_preMount_FIA";
 			init="[synchronizedObjects this, [""GrpFIA_ASL"",""GrpFIA_A1"",""GrpFIA_A2""], true, false] call f_fnc_mountGroups;";
-			id=1099;
+			id=3516;
 			type="Logic";
-			atlOffset=-5;
 		};
-		class Item366
+		class Item499
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={517.23132,0,778.17627};
+				position[]={510.69141,5,969.99707};
 			};
 			name="F3_preMount_FIA_1";
 			init="[synchronizedObjects this, [""GrpFIA_BSL"",""GrpFIA_B1"",""GrpFIA_B2""], true, false] call f_fnc_mountGroups;";
-			id=1105;
+			id=3517;
 			type="Logic";
-			atlOffset=-5;
 		};
-		class Item367
+		class Item500
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={558.604,0,780.34607};
+				position[]={552.06396,5,972.16687};
 			};
 			name="F3_preMount_FIA_2";
 			init="[synchronizedObjects this, [""GrpFIA_CSL"",""GrpFIA_C1"",""GrpFIA_C2""], true, false] call f_fnc_mountGroups;";
-			id=1106;
+			id=3518;
 			type="Logic";
-			atlOffset=-5;
 		};
-		class Item368
+		class Item501
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={435.57681,0,770.43823};
+				position[]={429.03687,5,962.25903};
 			};
 			name="F3_preMount_FIA_3";
 			init="[synchronizedObjects this, [""GrpFIA_CO""], true, false] call f_fnc_mountGroups;";
-			id=1107;
+			id=3519;
 			type="Logic";
-			atlOffset=-5;
 		};
-		class Item369
+		class Item502
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={437.03455,0,744.61487};
+				position[]={430.49463,5,936.43567};
 			};
 			name="F3_preMount_FIA_4";
 			init="[synchronizedObjects this, [""GrpFIA_DC""], true, false] call f_fnc_mountGroups;";
-			id=1108;
+			id=3520;
 			type="Logic";
-			atlOffset=-5;
 		};
-		class Item370
+		class Item503
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1441.297,0,786.68701};
+				position[]={1414.066,5,1387.2378};
 			};
 			name="F3_preMount_AAF";
 			init="[synchronizedObjects this, [""GrpAAF_ASL"",""GrpAAF_A1"",""GrpAAF_A2""], true, false] call f_fnc_mountGroups;";
-			id=1110;
+			id=3521;
 			type="Logic";
-			atlOffset=-5;
 		};
-		class Item371
+		class Item504
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1485.2041,0,788.32947};
+				position[]={1457.9731,5,1388.8804};
 			};
 			name="F3_preMount_AAF_1";
 			init="[synchronizedObjects this, [""GrpAAF_BSL"",""GrpAAF_B1"",""GrpAAF_B2""], true, false] call f_fnc_mountGroups;;";
-			id=1111;
+			id=3522;
 			type="Logic";
-			atlOffset=-5;
 		};
-		class Item372
+		class Item505
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1528.1724,0,788.09692};
+				position[]={1500.9414,5,1388.6477};
 			};
 			name="F3_preMount_AAF_2";
 			init="[synchronizedObjects this, [""GrpAAF_CSL"",""GrpAAF_C1"",""GrpAAF_C2""], true, false] call f_fnc_mountGroups;";
-			id=1112;
+			id=3523;
 			type="Logic";
-			atlOffset=-5;
 		};
-		class Item373
+		class Item506
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1398.5631,0,781.28723};
+				position[]={1371.3322,5,1381.8381};
 			};
 			name="F3_preMount_AAF_3";
 			init="[synchronizedObjects this, [""GrpAAF_CO""], true, false] call f_fnc_mountGroups;";
-			id=1113;
+			id=3524;
 			type="Logic";
-			atlOffset=-5;
 		};
-		class Item374
+		class Item507
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1397.389,0,753.11096};
+				position[]={1370.1581,5,1353.6619};
 			};
 			name="F3_preMount_AAF_4";
 			init="[synchronizedObjects this, [""GrpAAF_DC""], true, false] call f_fnc_mountGroups;";
-			id=1114;
+			id=3525;
 			type="Logic";
-			atlOffset=-5;
 		};
-		class Item375
+		class Item508
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -33561,11 +45093,11 @@ class Mission
 			};
 			name="F3_preMount_NATO";
 			init="[synchronizedObjects this, [""GrpNATO_ASL"",""GrpNATO_A1"",""GrpNATO_A2""], true, false] call f_fnc_mountGroups;";
-			id=1115;
+			id=3526;
 			type="Logic";
 			atlOffset=-5;
 		};
-		class Item376
+		class Item509
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -33574,11 +45106,11 @@ class Mission
 			};
 			name="F3_preMount_NATO_1";
 			init="[synchronizedObjects this, [""GrpNATO_BSL"",""GrpNATO_B1"",""GrpNATO_B2""], true, false] call f_fnc_mountGroups;";
-			id=1116;
+			id=3527;
 			type="Logic";
 			atlOffset=-5;
 		};
-		class Item377
+		class Item510
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -33587,11 +45119,11 @@ class Mission
 			};
 			name="F3_preMount_NATO_2";
 			init="[synchronizedObjects this, [""GrpNATO_CSL"",""GrpNATO_C1"",""GrpNATO_C2""], true, false] call f_fnc_mountGroups;";
-			id=1117;
+			id=3528;
 			type="Logic";
 			atlOffset=-5;
 		};
-		class Item378
+		class Item511
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -33600,11 +45132,11 @@ class Mission
 			};
 			name="F3_preMount_NATO_3";
 			init="[synchronizedObjects this, [""GrpNATO_CO""], true, false] call f_fnc_mountGroups;";
-			id=1118;
+			id=3529;
 			type="Logic";
 			atlOffset=-5;
 		};
-		class Item379
+		class Item512
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -33613,76 +45145,71 @@ class Mission
 			};
 			name="F3_preMount_NATO_4";
 			init="[synchronizedObjects this, [""GrpNATO_DC""], true, false] call f_fnc_mountGroups;";
-			id=1119;
+			id=3530;
 			type="Logic";
 			atlOffset=-5;
 		};
-		class Item380
+		class Item513
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1413.598,0,1409.447};
+				position[]={1418.957,5,996.89099};
 			};
 			name="F3_preMount_SYN";
 			init="[synchronizedObjects this, [""GrpSYN_ASL"",""GrpSYN_A1"",""GrpSYN_A2""], true, false] call f_fnc_mountGroups;";
-			id=1120;
+			id=3531;
 			type="Logic";
-			atlOffset=-5;
 		};
-		class Item381
+		class Item514
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1450.3208,0,1411.637};
+				position[]={1455.6798,5,999.08093};
 			};
 			name="F3_preMount_SYN_1";
 			init="[synchronizedObjects this, [""GrpSYN_BSL"",""GrpSYN_B1"",""GrpSYN_B2""], true, false] call f_fnc_mountGroups;";
-			id=1121;
+			id=3532;
 			type="Logic";
-			atlOffset=-5;
 		};
-		class Item382
+		class Item515
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1492.4077,0,1411.3385};
+				position[]={1497.7667,5,998.78235};
 			};
 			name="F3_preMount_SYN_2";
 			init="[synchronizedObjects this, [""GrpSYN_CSL"",""GrpSYN_C1"",""GrpSYN_C2""], true, false] call f_fnc_mountGroups;";
-			id=1122;
+			id=3533;
 			type="Logic";
-			atlOffset=-5;
 		};
-		class Item383
+		class Item516
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1360.4757,0,1389.549};
+				position[]={1365.8347,5,976.9928};
 			};
 			name="F3_preMount_SYN_3";
 			init="[synchronizedObjects this, [""GrpSYN_CO""], true, false] call f_fnc_mountGroups;";
-			id=1123;
+			id=3534;
 			type="Logic";
-			atlOffset=-5;
 		};
-		class Item384
+		class Item517
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1362.8638,0,1356.7145};
+				position[]={1368.2228,5,944.15833};
 			};
 			name="F3_preMount_SYN_4";
 			init="[synchronizedObjects this, [""GrpSYN_DC""], true, false] call f_fnc_mountGroups;";
-			id=1124;
+			id=3535;
 			type="Logic";
-			atlOffset=-5;
 		};
-		class Item385
+		class Item518
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -33691,11 +45218,11 @@ class Mission
 			};
 			name="F3_preMount_CSAT";
 			init="[synchronizedObjects this, [""GrpCSAT_ASL"",""GrpCSAT_A1"",""GrpCSAT_A2""], true, false] call f_fnc_mountGroups;";
-			id=1125;
+			id=3536;
 			type="Logic";
 			atlOffset=-5;
 		};
-		class Item386
+		class Item519
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -33704,11 +45231,11 @@ class Mission
 			};
 			name="F3_preMount_CSAT_1";
 			init="[synchronizedObjects this, [""GrpCSAT_BSL"",""GrpCSAT_B1"",""GrpCSAT_B2""], true, false] call f_fnc_mountGroups;";
-			id=1126;
+			id=3537;
 			type="Logic";
 			atlOffset=-5;
 		};
-		class Item387
+		class Item520
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -33717,11 +45244,11 @@ class Mission
 			};
 			name="F3_preMount_CSAT_2";
 			init="[synchronizedObjects this, [""GrpCSAT_CSL"",""GrpCSAT_C1"",""GrpCSAT_C2""], true, false] call f_fnc_mountGroups;";
-			id=1127;
+			id=3538;
 			type="Logic";
 			atlOffset=-5;
 		};
-		class Item388
+		class Item521
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -33730,11 +45257,11 @@ class Mission
 			};
 			name="F3_preMount_CSAT_3";
 			init="[synchronizedObjects this, [""GrpCSAT_CO""], true, false] call f_fnc_mountGroups;";
-			id=1128;
+			id=3539;
 			type="Logic";
 			atlOffset=-5;
 		};
-		class Item389
+		class Item522
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -33743,22 +45270,22 @@ class Mission
 			};
 			name="F3_preMount_CSAT_4";
 			init="[synchronizedObjects this, [""GrpCSAT_DC""], true, false] call f_fnc_mountGroups;";
-			id=1129;
+			id=3540;
 			type="Logic";
 			atlOffset=-5;
 		};
-		class Item390
+		class Item523
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={2900,5,800};
+				position[]={2783,5,575};
 			};
 			name="F3_Spectator";
 			init="if(isServer)then{" \n "  {" \n "     this setVariable [_x, this getVariable _x, true];" \n "  } forEach [""AllowFreeCamera"", ""WhitelistedSides"", ""ShowFocusInfo"", ""AllowAi"", ""Allow3PPCamera""];" \n "};";
 			isPlayable=1;
 			description="Spectator Slot";
-			id=1130;
+			id=3541;
 			type="VirtualSpectator_F";
 			class CustomAttributes
 			{
@@ -33859,18 +45386,18 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item391
+		class Item524
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={2900,5,766};
+				position[]={2783,5,541};
 			};
 			name="F3_Spectator_1";
 			init="if(isServer)then{" \n "  {" \n "     this setVariable [_x, this getVariable _x, true];" \n "  } forEach [""AllowFreeCamera"", ""WhitelistedSides"", ""ShowFocusInfo"", ""AllowAi"", ""Allow3PPCamera""];" \n "};";
 			isPlayable=1;
 			description="Spectator Slot";
-			id=1131;
+			id=3542;
 			type="VirtualSpectator_F";
 			class CustomAttributes
 			{
@@ -33971,18 +45498,18 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item392
+		class Item525
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={2900,5,733};
+				position[]={2783,5,508};
 			};
 			name="F3_Spectator_2";
 			init="if(isServer)then{" \n "  {" \n "     this setVariable [_x, this getVariable _x, true];" \n "  } forEach [""AllowFreeCamera"", ""WhitelistedSides"", ""ShowFocusInfo"", ""AllowAi"", ""Allow3PPCamera""];" \n "};";
 			isPlayable=1;
 			description="Spectator Slot";
-			id=1132;
+			id=3543;
 			type="VirtualSpectator_F";
 			class CustomAttributes
 			{
@@ -34083,18 +45610,18 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item393
+		class Item526
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={2900,5,700};
+				position[]={2783,5,475};
 			};
 			name="F3_Spectator_3";
 			init="if(isServer)then{" \n "  {" \n "     this setVariable [_x, this getVariable _x, true];" \n "  } forEach [""AllowFreeCamera"", ""WhitelistedSides"", ""ShowFocusInfo"", ""AllowAi"", ""Allow3PPCamera""];" \n "};";
 			isPlayable=1;
 			description="Spectator Slot";
-			id=1133;
+			id=3544;
 			type="VirtualSpectator_F";
 			class CustomAttributes
 			{
@@ -34195,7 +45722,7 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item394
+		class Item527
 		{
 			dataType="Object";
 			class PositionInfo
@@ -34210,10 +45737,10 @@ class Mission
 				name="VehNATO_CAS1";
 				receiveRemoteTargets=1;
 			};
-			id=1134;
+			id=3545;
 			type="B_Plane_CAS_01_dynamicLoadout_F";
 		};
-		class Item395
+		class Item528
 		{
 			dataType="Group";
 			side="West";
@@ -34240,7 +45767,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1136;
+					id=3547;
 					type="B_Fighter_Pilot_F";
 					class CustomAttributes
 					{
@@ -34290,7 +45817,7 @@ class Mission
 			{
 				name="GrpNATO_CAS1";
 			};
-			id=1135;
+			id=3546;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -34315,12 +45842,12 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item396
+		class Item529
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1383.8635,7.4227982,675.79047};
+				position[]={1356.6326,7.4227982,1276.3413};
 			};
 			side="Empty";
 			flags=4;
@@ -34330,10 +45857,10 @@ class Mission
 				name="VehAAF_CAS1";
 				receiveRemoteTargets=1;
 			};
-			id=1139;
+			id=3548;
 			type="I_Plane_Fighter_03_dynamicLoadout_F";
 		};
-		class Item397
+		class Item530
 		{
 			dataType="Group";
 			side="Independent";
@@ -34345,8 +45872,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1380.6572,5.0014391,679.09668};
-						angles[]={0,1.7658945,0};
+						position[]={1353.426,5.0014391,1279.6471};
+						angles[]={0,1.7658893,0};
 					};
 					side="Independent";
 					flags=6;
@@ -34360,7 +45887,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1143;
+					id=3550;
 					type="I_Fighter_Pilot_F";
 					class CustomAttributes
 					{
@@ -34410,7 +45937,7 @@ class Mission
 			{
 				name="GrpAAF_CAS1";
 			};
-			id=1142;
+			id=3549;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -34435,7 +45962,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item398
+		class Item531
 		{
 			dataType="Group";
 			side="East";
@@ -34461,7 +45988,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1145;
+					id=3552;
 					type="O_Fighter_Pilot_F";
 					class CustomAttributes
 					{
@@ -34511,7 +46038,7 @@ class Mission
 			{
 				name="GrpCSAT_CAS1";
 			};
-			id=1144;
+			id=3551;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -34536,7 +46063,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item399
+		class Item532
 		{
 			dataType="Object";
 			class PositionInfo
@@ -34551,15 +46078,15 @@ class Mission
 				name="VehCSAT_CAS1";
 				receiveRemoteTargets=1;
 			};
-			id=1146;
+			id=3553;
 			type="O_Plane_CAS_02_dynamicLoadout_F";
 		};
-		class Item400
+		class Item533
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1412.1403,5.8924227,1074.8203};
+				position[]={1425.3263,5.8924227,1768.1177};
 			};
 			side="Empty";
 			flags=4;
@@ -34569,7 +46096,7 @@ class Mission
 				init="[this,""3ifb""] call f_fnc_setVirtualFaction; [""crate_med"",this] call f_fnc_assignGear";
 				name="Crate3IFB_A";
 			};
-			id=1399;
+			id=3554;
 			type="IG_supplyCrate_F";
 			class CustomAttributes
 			{
@@ -34595,12 +46122,12 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item401
+		class Item534
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1454.1492,5.8924227,1075.9512};
+				position[]={1467.3352,5.8924227,1769.2485};
 			};
 			side="Empty";
 			flags=4;
@@ -34610,7 +46137,7 @@ class Mission
 				init="[this,""3ifb""] call f_fnc_setVirtualFaction; [""crate_med"",this] call f_fnc_assignGear";
 				name="Crate3IFB_B";
 			};
-			id=1400;
+			id=3555;
 			type="IG_supplyCrate_F";
 			class CustomAttributes
 			{
@@ -34636,12 +46163,12 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item402
+		class Item535
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1494.1052,5.8924227,1074.7432};
+				position[]={1507.2913,5.8924227,1768.0405};
 			};
 			side="Empty";
 			flags=4;
@@ -34651,7 +46178,7 @@ class Mission
 				init="[this,""3ifb""] call f_fnc_setVirtualFaction; [""crate_med"",this] call f_fnc_assignGear";
 				name="Crate3IFB_C";
 			};
-			id=1401;
+			id=3556;
 			type="IG_supplyCrate_F";
 			class CustomAttributes
 			{
@@ -34677,22 +46204,22 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item403
+		class Item536
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1355.8893,5,1062.4961};
+				position[]={1369.0753,5,1755.7935};
 			};
-			id=1538;
+			id=3557;
 			type="SupportProvider_Artillery";
 		};
-		class Item404
+		class Item537
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1532.8141,5.6047058,935.72253};
+				position[]={1546.0001,5.6047058,1629.0199};
 			};
 			side="Independent";
 			flags=6;
@@ -34703,17 +46230,17 @@ class Mission
 				name="Veh3IFB_TH1";
 				textures="Elliptical";
 			};
-			id=1405;
+			id=3558;
 			type="C_Heli_Light_01_civil_F";
 		};
-		class Item405
+		class Item538
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1357.984,5.4784107,1064.8203};
+				position[]={1371.17,5.4784107,1758.1177};
 			};
-			id=1417;
+			id=3559;
 			type="SupportRequester";
 			atlOffset=0.47841072;
 			class CustomAttributes
@@ -34854,7 +46381,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item406
+		class Item539
 		{
 			dataType="Group";
 			side="Independent";
@@ -34866,16 +46393,16 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1355.9049,5.3587284,1059.6226};
+						position[]={1369.0909,5.358439,1752.92};
 					};
 					side="Independent";
 					flags=2;
 					class Attributes
 					{
 					};
-					id=1419;
+					id=3561;
 					type="B_Soldier_F";
-					atlOffset=0.35728931;
+					atlOffset=0.35699987;
 				};
 			};
 			class Attributes
@@ -34893,8 +46420,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=1419;
-						item1=1420;
+						item0=3561;
+						item1=3562;
 						class CustomData
 						{
 							role=2;
@@ -34903,15 +46430,15 @@ class Mission
 					};
 				};
 			};
-			id=1418;
-			atlOffset=0.35728931;
+			id=3560;
+			atlOffset=0.35699987;
 		};
-		class Item407
+		class Item540
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1355.9049,6.0789151,1059.5721};
+				position[]={1369.0909,6.0786257,1752.8696};
 			};
 			side="Independent";
 			flags=2;
@@ -34920,11 +46447,11 @@ class Mission
 				skill=0.60000002;
 				init="[this,""3ifb""] call f_fnc_setVirtualFaction; ";
 			};
-			id=1420;
+			id=3562;
 			type="B_Mortar_01_F";
-			atlOffset=0.35728931;
+			atlOffset=0.35699987;
 		};
-		class Item408
+		class Item541
 		{
 			dataType="Group";
 			side="Independent";
@@ -34936,14 +46463,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1360.2526,5.0109735,1058.3986};
+						position[]={1373.4386,5.0109735,1751.696};
 					};
 					side="Independent";
 					flags=6;
 					class Attributes
 					{
 					};
-					id=1422;
+					id=3564;
 					type="B_Helipilot_F";
 					atlOffset=0.009534359;
 				};
@@ -34952,14 +46479,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1360.2526,5.0109735,1058.3986};
+						position[]={1373.4386,5.0109735,1751.696};
 					};
 					side="Independent";
 					flags=4;
 					class Attributes
 					{
 					};
-					id=1423;
+					id=3565;
 					type="B_Helipilot_F";
 					atlOffset=0.009534359;
 				};
@@ -34979,8 +46506,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=1422;
-						item1=1424;
+						item0=3564;
+						item1=3566;
 						class CustomData
 						{
 							role=1;
@@ -34989,8 +46516,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=1423;
-						item1=1424;
+						item0=3565;
+						item1=3566;
 						class CustomData
 						{
 							role=2;
@@ -34999,38 +46526,15 @@ class Mission
 					};
 				};
 			};
-			id=1421;
+			id=3563;
 			atlOffset=0.009534359;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="groupID";
-					expression="_this setGroupID [_value];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"STRING"
-								};
-							};
-							value=" -";
-						};
-					};
-				};
-				nAttributes=1;
-			};
 		};
-		class Item409
+		class Item542
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1360.2526,6.7886786,1058.3496};
+				position[]={1373.4386,6.7886786,1751.6471};
 			};
 			side="Independent";
 			flags=6;
@@ -35040,18 +46544,18 @@ class Mission
 				init="[this,""3ifb""] call f_fnc_setVirtualFaction; ";
 				receiveRemoteTargets=1;
 			};
-			id=1424;
+			id=3566;
 			type="B_Heli_Light_01_dynamicLoadout_F";
 			atlOffset=0.009534359;
 		};
-		class Item410
+		class Item543
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1358.8209,5.8319387,1040.9912};
+				position[]={1372.007,5.8319387,1734.2886};
 			};
-			id=1425;
+			id=3567;
 			type="SupportRequester";
 			atlOffset=0.83193874;
 			class CustomAttributes
@@ -35192,7 +46696,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item411
+		class Item544
 		{
 			dataType="Group";
 			side="Independent";
@@ -35204,14 +46708,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1356.7653,5.7404861,1035.8462};
+						position[]={1369.9513,5.7404861,1729.1436};
 					};
 					side="Independent";
 					flags=2;
 					class Attributes
 					{
 					};
-					id=1427;
+					id=3569;
 					type="B_Soldier_F";
 					atlOffset=0.73904705;
 				};
@@ -35231,8 +46735,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=1427;
-						item1=1428;
+						item0=3569;
+						item1=3570;
 						class CustomData
 						{
 							role=2;
@@ -35241,15 +46745,15 @@ class Mission
 					};
 				};
 			};
-			id=1426;
+			id=3568;
 			atlOffset=0.73904705;
 		};
-		class Item412
+		class Item545
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1356.7653,6.4606729,1035.7958};
+				position[]={1369.9513,6.4606729,1729.0931};
 			};
 			side="Independent";
 			flags=2;
@@ -35258,11 +46762,11 @@ class Mission
 				skill=0.60000002;
 				init="[this,""3ifb""] call f_fnc_setVirtualFaction; ";
 			};
-			id=1428;
+			id=3570;
 			type="B_Mortar_01_F";
 			atlOffset=0.73904705;
 		};
-		class Item413
+		class Item546
 		{
 			dataType="Group";
 			side="Independent";
@@ -35274,14 +46778,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1361.1305,5.2110257,1034.6027};
+						position[]={1374.3165,5.2110257,1727.9001};
 					};
 					side="Independent";
 					flags=6;
 					class Attributes
 					{
 					};
-					id=1430;
+					id=3572;
 					type="B_Helipilot_F";
 					atlOffset=0.20958662;
 				};
@@ -35290,14 +46794,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1361.1305,5.2110257,1034.6027};
+						position[]={1374.3165,5.2110257,1727.9001};
 					};
 					side="Independent";
 					flags=4;
 					class Attributes
 					{
 					};
-					id=1431;
+					id=3573;
 					type="B_Helipilot_F";
 					atlOffset=0.20958662;
 				};
@@ -35317,8 +46821,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=1430;
-						item1=1432;
+						item0=3572;
+						item1=3574;
 						class CustomData
 						{
 							role=1;
@@ -35327,8 +46831,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=1431;
-						item1=1432;
+						item0=3573;
+						item1=3574;
 						class CustomData
 						{
 							role=2;
@@ -35337,15 +46841,15 @@ class Mission
 					};
 				};
 			};
-			id=1429;
+			id=3571;
 			atlOffset=0.20958662;
 		};
-		class Item414
+		class Item547
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1361.1305,6.9887309,1034.5537};
+				position[]={1374.3165,6.9887309,1727.8512};
 			};
 			side="Independent";
 			flags=6;
@@ -35355,11 +46859,11 @@ class Mission
 				init="[this,""3ifb""] call f_fnc_setVirtualFaction; ";
 				receiveRemoteTargets=1;
 			};
-			id=1432;
+			id=3574;
 			type="B_Heli_Light_01_dynamicLoadout_F";
 			atlOffset=0.20958662;
 		};
-		class Item415
+		class Item548
 		{
 			dataType="Group";
 			side="Independent";
@@ -35371,7 +46875,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1374.589,5.0014391,1067.248};
+						position[]={1387.775,5.0014391,1760.5454};
 					};
 					side="Independent";
 					flags=6;
@@ -35385,7 +46889,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1560;
+					id=3576;
 					type="I_G_officer_F";
 					class CustomAttributes
 					{
@@ -35435,7 +46939,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1379.589,5.0014391,1065.597};
+						position[]={1392.775,5.0014391,1758.8945};
 					};
 					side="Independent";
 					flags=4;
@@ -35449,7 +46953,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1561;
+					id=3577;
 					type="I_G_officer_F";
 					class CustomAttributes
 					{
@@ -35499,7 +47003,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1370.1198,5.0014391,1064.2362};
+						position[]={1383.3058,5.0014391,1757.5337};
 					};
 					side="Independent";
 					flags=4;
@@ -35512,7 +47016,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1562;
+					id=3578;
 					type="I_G_Soldier_F";
 				};
 				class Item3
@@ -35520,7 +47024,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1384.5895,5.0014391,1062.8573};
+						position[]={1397.7755,5.0014391,1756.1548};
 					};
 					side="Independent";
 					flags=4;
@@ -35533,7 +47037,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1563;
+					id=3579;
 					type="I_G_medic_F";
 				};
 			};
@@ -35541,7 +47045,7 @@ class Mission
 			{
 				name="Grp3IFB_CO";
 			};
-			id=1433;
+			id=3575;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -35566,7 +47070,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item416
+		class Item549
 		{
 			dataType="Group";
 			side="Independent";
@@ -35578,7 +47082,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1374.0514,5.2133446,1042.8837};
+						position[]={1387.2374,5.2133446,1736.1812};
 					};
 					side="Independent";
 					flags=6;
@@ -35592,7 +47096,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1564;
+					id=3581;
 					type="I_G_officer_F";
 					atlOffset=0.21190548;
 					class CustomAttributes
@@ -35624,7 +47128,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1379.0514,5.2344303,1041.2333};
+						position[]={1392.2374,5.2344303,1734.5308};
 					};
 					side="Independent";
 					flags=4;
@@ -35638,7 +47142,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1565;
+					id=3582;
 					type="I_G_officer_F";
 					atlOffset=0.23299122;
 					class CustomAttributes
@@ -35670,7 +47174,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1369.0514,5.1082706,1041.2333};
+						position[]={1382.2374,5.1082706,1734.5308};
 					};
 					side="Independent";
 					flags=4;
@@ -35683,7 +47187,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1566;
+					id=3583;
 					type="I_G_Soldier_F";
 					atlOffset=0.10683155;
 					class CustomAttributes
@@ -35715,7 +47219,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1384.0514,5.1013861,1038.494};
+						position[]={1397.2374,5.1013861,1731.7915};
 					};
 					side="Independent";
 					flags=4;
@@ -35728,7 +47232,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1567;
+					id=3584;
 					type="I_G_medic_F";
 					atlOffset=0.099946976;
 					class CustomAttributes
@@ -35760,7 +47264,7 @@ class Mission
 			{
 				name="Grp3IFB_DC";
 			};
-			id=1438;
+			id=3580;
 			atlOffset=0.21190548;
 			class CustomAttributes
 			{
@@ -35786,7 +47290,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item417
+		class Item550
 		{
 			dataType="Group";
 			side="Independent";
@@ -35798,7 +47302,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1410.743,5.0014391,1066.639};
+						position[]={1423.9291,5.0014391,1759.9365};
 					};
 					side="Independent";
 					flags=6;
@@ -35812,7 +47316,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1568;
+					id=3586;
 					type="I_G_Soldier_SL_F";
 					class CustomAttributes
 					{
@@ -35862,7 +47366,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1415.7428,5.0014391,1064.9882};
+						position[]={1428.9288,5.0014391,1758.2856};
 					};
 					side="Independent";
 					flags=4;
@@ -35875,7 +47379,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1569;
+					id=3587;
 					type="I_G_medic_F";
 					class CustomAttributes
 					{
@@ -35906,7 +47410,7 @@ class Mission
 			{
 				name="Grp3IFB_ASL";
 			};
-			id=1443;
+			id=3585;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -35931,7 +47435,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item418
+		class Item551
 		{
 			dataType="Group";
 			side="Independent";
@@ -35943,7 +47447,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1411.3024,5.0014391,1045.1337};
+						position[]={1424.4884,5.0014391,1738.4312};
 					};
 					side="Independent";
 					flags=6;
@@ -35957,7 +47461,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1570;
+					id=3589;
 					type="I_G_Soldier_TL_F";
 					class CustomAttributes
 					{
@@ -35988,7 +47492,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1416.3024,5.0913763,1043.4833};
+						position[]={1429.4884,5.0913763,1736.7808};
 					};
 					side="Independent";
 					flags=4;
@@ -36002,7 +47506,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1571;
+					id=3590;
 					type="I_G_Soldier_AR_F";
 					atlOffset=0.08993721;
 					class CustomAttributes
@@ -36034,7 +47538,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1406.3024,5.0014391,1043.4833};
+						position[]={1419.4884,5.0014391,1736.7808};
 					};
 					side="Independent";
 					flags=4;
@@ -36048,7 +47552,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1572;
+					id=3591;
 					type="I_G_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -36079,7 +47583,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1421.3024,5.248991,1040.744};
+						position[]={1434.4884,5.248991,1734.0415};
 					};
 					side="Independent";
 					flags=4;
@@ -36093,7 +47597,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1573;
+					id=3592;
 					type="I_G_Soldier_LAT_F";
 					atlOffset=0.24755192;
 					class CustomAttributes
@@ -36125,7 +47629,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1401.3024,5.0014391,1040.744};
+						position[]={1414.4884,5.0014391,1734.0415};
 					};
 					side="Independent";
 					flags=4;
@@ -36138,7 +47642,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1574;
+					id=3593;
 					type="I_G_Soldier_F";
 					class CustomAttributes
 					{
@@ -36169,7 +47673,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1426.3024,5.0014391,1036.1971};
+						position[]={1439.4884,5.0014391,1729.4946};
 					};
 					side="Independent";
 					flags=4;
@@ -36182,7 +47686,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1575;
+					id=3594;
 					type="I_G_Soldier_F";
 					class CustomAttributes
 					{
@@ -36213,7 +47717,7 @@ class Mission
 			{
 				name="Grp3IFB_A1";
 			};
-			id=1446;
+			id=3588;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -36238,7 +47742,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item419
+		class Item552
 		{
 			dataType="Group";
 			side="Independent";
@@ -36250,7 +47754,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1411.066,5.0014391,1021.2548};
+						position[]={1424.2521,5.0014391,1714.5522};
 					};
 					side="Independent";
 					flags=6;
@@ -36264,7 +47768,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1576;
+					id=3596;
 					type="I_G_Soldier_TL_F";
 					class CustomAttributes
 					{
@@ -36295,7 +47799,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1416.066,5.0014391,1019.6044};
+						position[]={1429.2521,5.0014391,1712.9019};
 					};
 					side="Independent";
 					flags=4;
@@ -36309,7 +47813,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1577;
+					id=3597;
 					type="I_G_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -36340,7 +47844,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1406.066,5.0014391,1019.6044};
+						position[]={1419.2521,5.0014391,1712.9019};
 					};
 					side="Independent";
 					flags=4;
@@ -36354,7 +47858,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1578;
+					id=3598;
 					type="I_G_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -36385,7 +47889,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1421.066,5.0014391,1016.8651};
+						position[]={1434.2521,5.0014391,1710.1626};
 					};
 					side="Independent";
 					flags=4;
@@ -36399,7 +47903,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1579;
+					id=3599;
 					type="I_G_Soldier_LAT_F";
 					class CustomAttributes
 					{
@@ -36430,7 +47934,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1401.066,5.0014391,1016.8651};
+						position[]={1414.2521,5.0014391,1710.1626};
 					};
 					side="Independent";
 					flags=4;
@@ -36443,7 +47947,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1580;
+					id=3600;
 					type="I_G_Soldier_F";
 					class CustomAttributes
 					{
@@ -36474,7 +47978,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1426.066,5.0014391,1012.3182};
+						position[]={1439.2521,5.0014391,1705.6157};
 					};
 					side="Independent";
 					flags=4;
@@ -36487,7 +47991,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1581;
+					id=3601;
 					type="I_G_Soldier_F";
 					class CustomAttributes
 					{
@@ -36518,7 +48022,7 @@ class Mission
 			{
 				name="Grp3IFB_A2";
 			};
-			id=1453;
+			id=3595;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -36543,7 +48047,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item420
+		class Item553
 		{
 			dataType="Group";
 			side="Independent";
@@ -36555,7 +48059,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1451.425,5.0014391,1066.592};
+						position[]={1464.6111,5.0014391,1759.8894};
 					};
 					side="Independent";
 					flags=6;
@@ -36569,7 +48073,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1582;
+					id=3603;
 					type="I_G_Soldier_SL_F";
 					class CustomAttributes
 					{
@@ -36619,7 +48123,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1456.4246,5.0014391,1064.9413};
+						position[]={1469.6106,5.0014391,1758.2388};
 					};
 					side="Independent";
 					flags=4;
@@ -36632,7 +48136,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1583;
+					id=3604;
 					type="I_G_medic_F";
 					class CustomAttributes
 					{
@@ -36663,7 +48167,7 @@ class Mission
 			{
 				name="Grp3IFB_BSL";
 			};
-			id=1460;
+			id=3602;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -36688,7 +48192,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item421
+		class Item554
 		{
 			dataType="Group";
 			side="Independent";
@@ -36700,7 +48204,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1452.1912,5.0014391,1044.8964};
+						position[]={1465.3772,5.0014391,1738.1938};
 					};
 					side="Independent";
 					flags=6;
@@ -36714,7 +48218,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1584;
+					id=3606;
 					type="I_G_Soldier_TL_F";
 				};
 				class Item1
@@ -36722,7 +48226,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1457.1912,5.0014391,1043.2469};
+						position[]={1470.3772,5.0014391,1736.5444};
 					};
 					side="Independent";
 					flags=4;
@@ -36736,7 +48240,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1585;
+					id=3607;
 					type="I_G_Soldier_AR_F";
 					class CustomAttributes
 					{
@@ -36767,7 +48271,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1447.1912,5.0014391,1043.2469};
+						position[]={1460.3772,5.0014391,1736.5444};
 					};
 					side="Independent";
 					flags=4;
@@ -36781,7 +48285,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1586;
+					id=3608;
 					type="I_G_Soldier_AR_F";
 				};
 				class Item3
@@ -36789,7 +48293,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1462.1912,5.0014391,1040.5067};
+						position[]={1475.3772,5.0014391,1733.8042};
 					};
 					side="Independent";
 					flags=4;
@@ -36803,7 +48307,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1587;
+					id=3609;
 					type="I_G_Soldier_LAT_F";
 				};
 				class Item4
@@ -36811,7 +48315,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1442.1912,5.0014391,1040.5067};
+						position[]={1455.3772,5.0014391,1733.8042};
 					};
 					side="Independent";
 					flags=4;
@@ -36824,7 +48328,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1588;
+					id=3610;
 					type="I_G_Soldier_F";
 				};
 				class Item5
@@ -36832,7 +48336,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1467.1912,5.0014391,1035.9608};
+						position[]={1480.3772,5.0014391,1729.2583};
 					};
 					side="Independent";
 					flags=4;
@@ -36845,7 +48349,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1589;
+					id=3611;
 					type="I_G_Soldier_F";
 				};
 			};
@@ -36853,7 +48357,7 @@ class Mission
 			{
 				name="Grp3IFB_B1";
 			};
-			id=1463;
+			id=3605;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -36878,7 +48382,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item422
+		class Item555
 		{
 			dataType="Group";
 			side="Independent";
@@ -36890,7 +48394,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1451.6316,5.0014391,1021.6688};
+						position[]={1464.8176,5.0014391,1714.9663};
 					};
 					side="Independent";
 					flags=6;
@@ -36904,7 +48408,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1590;
+					id=3613;
 					type="I_G_Soldier_TL_F";
 				};
 				class Item1
@@ -36912,7 +48416,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1456.6316,5.0014391,1020.0175};
+						position[]={1469.8176,5.0014391,1713.3149};
 					};
 					side="Independent";
 					flags=4;
@@ -36926,7 +48430,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1591;
+					id=3614;
 					type="I_G_Soldier_AR_F";
 				};
 				class Item2
@@ -36934,7 +48438,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1446.6316,5.0014391,1020.0175};
+						position[]={1459.8176,5.0014391,1713.3149};
 					};
 					side="Independent";
 					flags=4;
@@ -36948,7 +48452,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1592;
+					id=3615;
 					type="I_G_Soldier_AR_F";
 				};
 				class Item3
@@ -36956,7 +48460,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1461.6316,5.0014391,1017.2782};
+						position[]={1474.8176,5.0014391,1710.5757};
 					};
 					side="Independent";
 					flags=4;
@@ -36970,7 +48474,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1593;
+					id=3616;
 					type="I_G_Soldier_LAT_F";
 				};
 				class Item4
@@ -36978,7 +48482,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1441.6316,5.0014391,1017.2782};
+						position[]={1454.8176,5.0014391,1710.5757};
 					};
 					side="Independent";
 					flags=4;
@@ -36991,7 +48495,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1594;
+					id=3617;
 					type="I_G_Soldier_F";
 				};
 				class Item5
@@ -36999,7 +48503,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1466.6316,5.0014391,1012.7313};
+						position[]={1479.8176,5.0014391,1706.0288};
 					};
 					side="Independent";
 					flags=4;
@@ -37012,7 +48516,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1595;
+					id=3618;
 					type="I_G_Soldier_F";
 				};
 			};
@@ -37020,7 +48524,7 @@ class Mission
 			{
 				name="Grp3IFB_B2";
 			};
-			id=1470;
+			id=3612;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -37045,7 +48549,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item423
+		class Item556
 		{
 			dataType="Group";
 			side="Independent";
@@ -37057,7 +48561,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1494.6082,5.3023081,1065.995};
+						position[]={1507.7942,5.3023081,1759.2925};
 					};
 					side="Independent";
 					flags=2;
@@ -37071,16 +48575,39 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1596;
+					id=3620;
 					type="I_G_Soldier_SL_F";
 					atlOffset=0.30086899;
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male02GRE";
+								};
+							};
+						};
+						nAttributes=1;
+					};
 				};
 				class Item1
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1499.6082,5.6464462,1064.3446};
+						position[]={1512.7942,5.6464462,1757.6421};
 					};
 					side="Independent";
 					class Attributes
@@ -37092,16 +48619,39 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1597;
+					id=3621;
 					type="I_G_medic_F";
 					atlOffset=0.64500713;
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male02GRE";
+								};
+							};
+						};
+						nAttributes=1;
+					};
 				};
 			};
 			class Attributes
 			{
 				name="Grp3IFB_CSL";
 			};
-			id=1477;
+			id=3619;
 			atlOffset=0.30086899;
 			class CustomAttributes
 			{
@@ -37127,7 +48677,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item424
+		class Item557
 		{
 			dataType="Group";
 			side="Independent";
@@ -37139,7 +48689,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1495.0095,5.0014391,1044.2352};
+						position[]={1508.1956,5.0014391,1737.5327};
 					};
 					side="Independent";
 					flags=6;
@@ -37153,7 +48703,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1598;
+					id=3623;
 					type="I_G_Soldier_TL_F";
 				};
 				class Item1
@@ -37161,7 +48711,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1500.0095,5.0014391,1042.5858};
+						position[]={1513.1956,5.0014391,1735.8833};
 					};
 					side="Independent";
 					flags=4;
@@ -37175,7 +48725,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1599;
+					id=3624;
 					type="I_G_Soldier_AR_F";
 				};
 				class Item2
@@ -37183,7 +48733,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1490.0095,5.0014391,1042.5858};
+						position[]={1503.1956,5.0014391,1735.8833};
 					};
 					side="Independent";
 					flags=4;
@@ -37197,7 +48747,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1600;
+					id=3625;
 					type="I_G_Soldier_AR_F";
 				};
 				class Item3
@@ -37205,7 +48755,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1505.0095,5.0014391,1039.8456};
+						position[]={1518.1956,5.0014391,1733.1431};
 					};
 					side="Independent";
 					flags=4;
@@ -37219,7 +48769,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1601;
+					id=3626;
 					type="I_G_Soldier_LAT_F";
 				};
 				class Item4
@@ -37227,7 +48777,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1485.0095,5.0014391,1039.8456};
+						position[]={1498.1956,5.0014391,1733.1431};
 					};
 					side="Independent";
 					flags=4;
@@ -37240,7 +48790,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1602;
+					id=3627;
 					type="I_G_Soldier_F";
 				};
 				class Item5
@@ -37248,7 +48798,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1510.0095,5.0014391,1035.2987};
+						position[]={1523.1956,5.0014391,1728.5962};
 					};
 					side="Independent";
 					flags=4;
@@ -37261,7 +48811,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1603;
+					id=3628;
 					type="I_G_Soldier_F";
 				};
 			};
@@ -37269,7 +48819,7 @@ class Mission
 			{
 				name="Grp3IFB_C1";
 			};
-			id=1480;
+			id=3622;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -37294,7 +48844,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item425
+		class Item558
 		{
 			dataType="Group";
 			side="Independent";
@@ -37306,7 +48856,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1495.3142,5.0014391,1021.1317};
+						position[]={1508.5002,5.0014391,1714.4292};
 					};
 					side="Independent";
 					flags=6;
@@ -37320,7 +48870,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1604;
+					id=3630;
 					type="I_G_Soldier_TL_F";
 				};
 				class Item1
@@ -37328,7 +48878,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1500.3142,5.0014391,1019.4813};
+						position[]={1513.5002,5.0014391,1712.7788};
 					};
 					side="Independent";
 					flags=4;
@@ -37342,7 +48892,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1605;
+					id=3631;
 					type="I_G_Soldier_AR_F";
 				};
 				class Item2
@@ -37350,7 +48900,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1490.3142,5.0014391,1019.4813};
+						position[]={1503.5002,5.0014391,1712.7788};
 					};
 					side="Independent";
 					flags=4;
@@ -37364,7 +48914,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1606;
+					id=3632;
 					type="I_G_Soldier_AR_F";
 				};
 				class Item3
@@ -37372,7 +48922,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1505.3142,5.0014391,1016.7421};
+						position[]={1518.5002,5.0014391,1710.0396};
 					};
 					side="Independent";
 					flags=4;
@@ -37386,7 +48936,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1607;
+					id=3633;
 					type="I_G_Soldier_LAT_F";
 				};
 				class Item4
@@ -37394,7 +48944,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1485.3142,5.0014391,1016.7421};
+						position[]={1498.5002,5.0014391,1710.0396};
 					};
 					side="Independent";
 					flags=4;
@@ -37407,7 +48957,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1608;
+					id=3634;
 					type="I_G_Soldier_F";
 				};
 				class Item5
@@ -37415,7 +48965,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1510.3142,5.0014391,1012.1942};
+						position[]={1523.5002,5.0014391,1705.4917};
 					};
 					side="Independent";
 					flags=4;
@@ -37428,7 +48978,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1609;
+					id=3635;
 					type="I_G_Soldier_F";
 				};
 			};
@@ -37436,7 +48986,7 @@ class Mission
 			{
 				name="Grp3IFB_C2";
 			};
-			id=1487;
+			id=3629;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -37461,7 +49011,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item426
+		class Item559
 		{
 			dataType="Group";
 			side="Independent";
@@ -37473,7 +49023,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1531.2993,5.153439,1066.2166};
+						position[]={1544.4854,5.153439,1759.5139};
 					};
 					side="Independent";
 					flags=6;
@@ -37487,7 +49037,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1610;
+					id=3637;
 					type="I_G_Soldier_TL_F";
 					atlOffset=0.15199995;
 				};
@@ -37496,7 +49046,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1536.2996,5.2476587,1064.5663};
+						position[]={1549.4856,5.2476587,1757.8638};
 					};
 					side="Independent";
 					flags=4;
@@ -37509,7 +49059,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1611;
+					id=3638;
 					type="I_G_Soldier_AR_F";
 					atlOffset=0.24621964;
 				};
@@ -37518,7 +49068,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1527.1372,5.153439,1064.5956};
+						position[]={1540.3232,5.153439,1757.8931};
 					};
 					side="Independent";
 					flags=4;
@@ -37532,7 +49082,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1612;
+					id=3639;
 					type="I_G_Soldier_lite_F";
 					atlOffset=0.15199995;
 				};
@@ -37541,7 +49091,7 @@ class Mission
 			{
 				name="Grp3IFB_MMG1";
 			};
-			id=1494;
+			id=3636;
 			atlOffset=0.15199995;
 			class CustomAttributes
 			{
@@ -37567,7 +49117,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item427
+		class Item560
 		{
 			dataType="Group";
 			side="Independent";
@@ -37579,7 +49129,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1531.1594,5.0014391,1054.8776};
+						position[]={1544.3455,5.0014391,1748.175};
 					};
 					side="Independent";
 					flags=6;
@@ -37593,7 +49143,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1613;
+					id=3641;
 					type="I_G_Soldier_TL_F";
 				};
 				class Item1
@@ -37601,7 +49151,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1536.1599,5.0014391,1053.2274};
+						position[]={1549.3459,5.0014391,1746.5249};
 					};
 					side="Independent";
 					flags=4;
@@ -37614,7 +49164,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1614;
+					id=3642;
 					type="I_G_Soldier_AR_F";
 				};
 				class Item2
@@ -37622,7 +49172,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1526.9973,5.0014391,1053.2566};
+						position[]={1540.1833,5.0014391,1746.554};
 					};
 					side="Independent";
 					flags=4;
@@ -37636,7 +49186,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1615;
+					id=3643;
 					type="I_G_Soldier_lite_F";
 				};
 			};
@@ -37644,7 +49194,7 @@ class Mission
 			{
 				name="Grp3IFB_MMG2";
 			};
-			id=1498;
+			id=3640;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -37669,7 +49219,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item428
+		class Item561
 		{
 			dataType="Group";
 			side="Independent";
@@ -37681,7 +49231,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1531.5034,5.0014391,1044.1696};
+						position[]={1544.6895,5.0014391,1737.467};
 					};
 					side="Independent";
 					flags=6;
@@ -37695,7 +49245,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1616;
+					id=3645;
 					type="I_G_Soldier_TL_F";
 				};
 				class Item1
@@ -37703,7 +49253,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1536.5037,5.0014391,1042.5194};
+						position[]={1549.6897,5.0014391,1735.8169};
 					};
 					side="Independent";
 					flags=4;
@@ -37716,7 +49266,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1617;
+					id=3646;
 					type="I_G_Soldier_LAT_F";
 				};
 				class Item2
@@ -37724,7 +49274,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1527.3413,5.0014391,1042.5486};
+						position[]={1540.5273,5.0014391,1735.8459};
 					};
 					side="Independent";
 					flags=4;
@@ -37738,7 +49288,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1618;
+					id=3647;
 					type="I_G_Soldier_LAT_F";
 				};
 			};
@@ -37746,7 +49296,7 @@ class Mission
 			{
 				name="Grp3IFB_MAT1";
 			};
-			id=1502;
+			id=3644;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -37771,7 +49321,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item429
+		class Item562
 		{
 			dataType="Group";
 			side="Independent";
@@ -37783,7 +49333,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1531.4164,5.0014391,1032.1875};
+						position[]={1544.6024,5.0014391,1725.4849};
 					};
 					side="Independent";
 					flags=6;
@@ -37797,7 +49347,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1619;
+					id=3649;
 					type="I_G_Soldier_TL_F";
 				};
 				class Item1
@@ -37805,7 +49355,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1536.4167,5.0014391,1030.537};
+						position[]={1549.6028,5.0014391,1723.8345};
 					};
 					side="Independent";
 					flags=4;
@@ -37819,7 +49369,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1620;
+					id=3650;
 					type="I_G_Soldier_LAT_F";
 				};
 				class Item2
@@ -37827,7 +49377,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1527.2544,5.0014391,1030.5656};
+						position[]={1540.4404,5.0014391,1723.863};
 					};
 					side="Independent";
 					flags=4;
@@ -37841,7 +49391,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1621;
+					id=3651;
 					type="I_G_Soldier_LAT_F";
 				};
 			};
@@ -37849,7 +49399,7 @@ class Mission
 			{
 				name="Grp3IFB_MAT2";
 			};
-			id=1506;
+			id=3648;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -37874,7 +49424,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item430
+		class Item563
 		{
 			dataType="Group";
 			side="Independent";
@@ -37886,7 +49436,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1531.905,5.0014391,1021.2889};
+						position[]={1545.0911,5.0014391,1714.5864};
 					};
 					side="Independent";
 					flags=6;
@@ -37900,7 +49450,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1622;
+					id=3653;
 					type="I_G_Soldier_TL_F";
 				};
 				class Item1
@@ -37908,7 +49458,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1536.905,5.0014391,1019.6385};
+						position[]={1550.0911,5.0014391,1712.936};
 					};
 					side="Independent";
 					flags=4;
@@ -37921,7 +49471,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1623;
+					id=3654;
 					type="I_G_Soldier_AR_F";
 				};
 			};
@@ -37929,7 +49479,7 @@ class Mission
 			{
 				name="Grp3IFB_HMG1";
 			};
-			id=1510;
+			id=3652;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -37954,7 +49504,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item431
+		class Item564
 		{
 			dataType="Group";
 			side="Independent";
@@ -37966,7 +49516,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1531.7294,5.0014391,1008.8856};
+						position[]={1544.9154,5.0014391,1702.1831};
 					};
 					side="Independent";
 					flags=6;
@@ -37980,7 +49530,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1624;
+					id=3656;
 					type="I_G_Soldier_TL_F";
 				};
 				class Item1
@@ -37988,7 +49538,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1536.7292,5.2301273,1007.2352};
+						position[]={1549.9153,5.2301273,1700.5327};
 					};
 					side="Independent";
 					flags=4;
@@ -38002,7 +49552,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1625;
+					id=3657;
 					type="I_G_Soldier_LAT_F";
 					atlOffset=0.22868824;
 				};
@@ -38011,7 +49561,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1527.5664,5.0014391,1007.2635};
+						position[]={1540.7524,5.0014391,1700.561};
 					};
 					side="Independent";
 					flags=4;
@@ -38025,7 +49575,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1626;
+					id=3658;
 					type="I_G_Soldier_LAT_F";
 				};
 			};
@@ -38033,7 +49583,7 @@ class Mission
 			{
 				name="Grp3IFB_HAT1";
 			};
-			id=1513;
+			id=3655;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -38058,7 +49608,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item432
+		class Item565
 		{
 			dataType="Group";
 			side="Independent";
@@ -38070,7 +49620,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1531.7312,5.0014391,997.11707};
+						position[]={1544.9172,5.0014391,1690.4146};
 					};
 					side="Independent";
 					flags=6;
@@ -38084,7 +49634,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1627;
+					id=3660;
 					type="I_G_Soldier_F";
 				};
 				class Item1
@@ -38092,7 +49642,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1536.7312,5.3897858,995.46667};
+						position[]={1549.9172,5.3897858,1688.7642};
 					};
 					side="Independent";
 					class Attributes
@@ -38105,7 +49655,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1628;
+					id=3661;
 					type="I_G_Soldier_A_F";
 					atlOffset=0.38834667;
 				};
@@ -38114,7 +49664,7 @@ class Mission
 			{
 				name="Grp3IFB_MTR1";
 			};
-			id=1517;
+			id=3659;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -38139,7 +49689,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item433
+		class Item566
 		{
 			dataType="Group";
 			side="Independent";
@@ -38151,7 +49701,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1531.7305,5.0014391,984.59955};
+						position[]={1544.9165,5.0014391,1677.897};
 					};
 					side="Independent";
 					flags=6;
@@ -38165,7 +49715,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1629;
+					id=3663;
 					type="I_G_Soldier_LAT_F";
 				};
 				class Item1
@@ -38173,7 +49723,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1536.7302,5.5413675,982.9491};
+						position[]={1549.9163,5.5413675,1676.2466};
 					};
 					side="Independent";
 					class Attributes
@@ -38186,7 +49736,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1630;
+					id=3664;
 					type="I_G_Soldier_LAT_F";
 					atlOffset=0.53992844;
 				};
@@ -38195,7 +49745,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1527.5674,5.0014391,982.97754};
+						position[]={1540.7534,5.0014391,1676.2749};
 					};
 					side="Independent";
 					flags=4;
@@ -38209,7 +49759,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1631;
+					id=3665;
 					type="I_G_Soldier_LAT_F";
 				};
 			};
@@ -38217,7 +49767,7 @@ class Mission
 			{
 				name="Grp3IFB_MSAM1";
 			};
-			id=1520;
+			id=3662;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -38242,7 +49792,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item434
+		class Item567
 		{
 			dataType="Group";
 			side="Independent";
@@ -38254,7 +49804,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1531.6296,5.0014391,971.82507};
+						position[]={1544.8157,5.0014391,1665.1226};
 					};
 					side="Independent";
 					flags=6;
@@ -38268,7 +49818,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1632;
+					id=3667;
 					type="I_G_Soldier_LAT_F";
 				};
 				class Item1
@@ -38276,7 +49826,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1536.6296,5.0014391,970.17468};
+						position[]={1549.8157,5.0014391,1663.4722};
 					};
 					side="Independent";
 					flags=4;
@@ -38290,7 +49840,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1633;
+					id=3668;
 					type="I_G_Soldier_LAT_F";
 				};
 			};
@@ -38298,7 +49848,7 @@ class Mission
 			{
 				name="Grp3IFB_HSAM1";
 			};
-			id=1524;
+			id=3666;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -38323,7 +49873,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item435
+		class Item568
 		{
 			dataType="Group";
 			side="Independent";
@@ -38335,7 +49885,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1531.5027,5.0014391,960.9198};
+						position[]={1544.6887,5.0014391,1654.2173};
 					};
 					side="Independent";
 					flags=6;
@@ -38349,7 +49899,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1634;
+					id=3670;
 					type="I_G_Soldier_M_F";
 				};
 				class Item1
@@ -38357,7 +49907,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1536.5027,5.0014391,959.26941};
+						position[]={1549.6887,5.0014391,1652.5669};
 					};
 					side="Independent";
 					flags=4;
@@ -38371,7 +49921,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1635;
+					id=3671;
 					type="I_G_Soldier_M_F";
 				};
 			};
@@ -38379,7 +49929,7 @@ class Mission
 			{
 				name="Grp3IFB_ST1";
 			};
-			id=1527;
+			id=3669;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -38404,7 +49954,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item436
+		class Item569
 		{
 			dataType="Group";
 			side="Independent";
@@ -38416,7 +49966,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1532.2742,5.0014391,948.57312};
+						position[]={1545.4602,5.0014391,1641.8706};
 					};
 					side="Independent";
 					flags=6;
@@ -38430,7 +49980,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1636;
+					id=3673;
 					type="I_G_engineer_F";
 				};
 				class Item1
@@ -38438,7 +49988,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1537.2742,5.0014391,946.92273};
+						position[]={1550.4602,5.0014391,1640.2202};
 					};
 					side="Independent";
 					flags=4;
@@ -38451,7 +50001,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1637;
+					id=3674;
 					type="I_G_engineer_F";
 				};
 				class Item2
@@ -38459,7 +50009,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1527.2742,5.0014391,946.92273};
+						position[]={1540.4602,5.0014391,1640.2202};
 					};
 					side="Independent";
 					flags=4;
@@ -38472,7 +50022,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1638;
+					id=3675;
 					type="I_G_engineer_F";
 				};
 				class Item3
@@ -38480,7 +50030,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1542.2742,5.0014391,944.18347};
+						position[]={1555.4602,5.0014391,1637.481};
 					};
 					side="Independent";
 					flags=4;
@@ -38493,7 +50043,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1639;
+					id=3676;
 					type="I_G_engineer_F";
 				};
 			};
@@ -38501,7 +50051,7 @@ class Mission
 			{
 				name="Grp3IFB_ENG1";
 			};
-			id=1530;
+			id=3672;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -38526,7 +50076,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item437
+		class Item570
 		{
 			dataType="Group";
 			side="Independent";
@@ -38538,7 +50088,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1378.1918,5.0014391,983.27466};
+						position[]={1391.3781,5.0014391,1676.572};
 					};
 					side="Independent";
 					flags=4;
@@ -38551,7 +50101,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1650;
+					id=3678;
 					type="I_G_Soldier_F";
 					class CustomAttributes
 					{
@@ -38582,7 +50132,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1378.1918,5.0014391,983.27466};
+						position[]={1391.3781,5.0014391,1676.572};
 					};
 					side="Independent";
 					flags=6;
@@ -38596,7 +50146,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1651;
+					id=3679;
 					type="I_G_Soldier_F";
 					class CustomAttributes
 					{
@@ -38639,8 +50189,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=1650;
-						item1=1652;
+						item0=3678;
+						item1=3704;
 						class CustomData
 						{
 							role=1;
@@ -38649,8 +50199,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=1651;
-						item1=1652;
+						item0=3679;
+						item1=3704;
 						class CustomData
 						{
 							role=2;
@@ -38659,7 +50209,7 @@ class Mission
 					};
 				};
 			};
-			id=1642;
+			id=3677;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -38677,14 +50227,14 @@ class Mission
 									"STRING"
 								};
 							};
-							value="3IFB IFV1 -";
+							value="3IFB TECH1 -";
 						};
 					};
 				};
 				nAttributes=1;
 			};
 		};
-		class Item438
+		class Item571
 		{
 			dataType="Group";
 			side="Independent";
@@ -38696,7 +50246,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1412.9154,5.0014391,983.19165};
+						position[]={1426.101,5.0014391,1676.489};
 					};
 					side="Independent";
 					flags=6;
@@ -38710,7 +50260,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1653;
+					id=3681;
 					type="I_G_Soldier_F";
 					class CustomAttributes
 					{
@@ -38741,7 +50291,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1412.9154,5.0014391,983.19165};
+						position[]={1426.101,5.0014391,1676.489};
 					};
 					side="Independent";
 					flags=4;
@@ -38754,7 +50304,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1654;
+					id=3682;
 					type="I_G_Soldier_F";
 					class CustomAttributes
 					{
@@ -38797,8 +50347,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=1653;
-						item1=1655;
+						item0=3681;
+						item1=3705;
 						class CustomData
 						{
 							role=2;
@@ -38808,8 +50358,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=1654;
-						item1=1655;
+						item0=3682;
+						item1=3705;
 						class CustomData
 						{
 							role=1;
@@ -38817,7 +50367,7 @@ class Mission
 					};
 				};
 			};
-			id=1646;
+			id=3680;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -38835,25 +50385,25 @@ class Mission
 									"STRING"
 								};
 							};
-							value="3IFB IFV2 -";
+							value="3IFB TECH2 -";
 						};
 					};
 				};
 				nAttributes=1;
 			};
 		};
-		class Item439
+		class Item572
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1356.7262,5.8610754,1038.666};
+				position[]={1369.9122,5.8610754,1731.9634};
 			};
-			id=1537;
+			id=3683;
 			type="SupportProvider_Artillery";
 			atlOffset=0.8610754;
 		};
-		class Item440
+		class Item573
 		{
 			dataType="Group";
 			side="Independent";
@@ -38865,7 +50415,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1532.814,5.0014391,936.75256};
+						position[]={1546,5.0014391,1630.05};
 					};
 					side="Independent";
 					flags=6;
@@ -38879,7 +50429,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1640;
+					id=3685;
 					type="I_G_engineer_F";
 				};
 				class Item1
@@ -38887,7 +50437,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1532.814,5.0014391,936.75256};
+						position[]={1546,5.0014391,1630.05};
 					};
 					side="Independent";
 					flags=4;
@@ -38901,7 +50451,7 @@ class Mission
 						isPlayable=1;
 						reportRemoteTargets=1;
 					};
-					id=1641;
+					id=3686;
 					type="I_G_engineer_F";
 				};
 			};
@@ -38921,8 +50471,8 @@ class Mission
 					class Item0
 					{
 						linkID=0;
-						item0=1640;
-						item1=1405;
+						item0=3685;
+						item1=3558;
 						class CustomData
 						{
 							role=1;
@@ -38931,8 +50481,8 @@ class Mission
 					class Item1
 					{
 						linkID=1;
-						item0=1641;
-						item1=1405;
+						item0=3686;
+						item1=3558;
 						class CustomData
 						{
 							role=2;
@@ -38941,7 +50491,7 @@ class Mission
 					};
 				};
 			};
-			id=1402;
+			id=3684;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -38966,77 +50516,72 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item441
+		class Item574
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1401.9275,0,1086.1885};
+				position[]={1415.1135,5,1779.4858};
 			};
 			name="F3_preMount_3IFB_5";
 			init="[synchronizedObjects this, [""Grp3IFB_ASL"",""Grp3IFB_A1"",""Grp3IFB_A2""], true, false] call f_fnc_mountGroups;";
-			id=1539;
+			id=3687;
 			type="Logic";
-			atlOffset=-5;
 		};
-		class Item442
+		class Item575
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1445.5618,0,1088.2759};
+				position[]={1458.7478,5,1781.5732};
 			};
 			name="F3_preMount_3IFB_6";
 			init="[synchronizedObjects this, [""Grp3IFB_BSL"",""Grp3IFB_B1"",""Grp3IFB_B2""], true, false] call f_fnc_mountGroups;";
-			id=1540;
+			id=3688;
 			type="Logic";
-			atlOffset=-5;
 		};
-		class Item443
+		class Item576
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1486.9343,0,1090.4456};
+				position[]={1500.1204,5,1783.7429};
 			};
 			name="F3_preMount_3IFB_7";
 			init="[synchronizedObjects this, [""Grp3IFB_CSL"",""Grp3IFB_C1"",""Grp3IFB_C2""], true, false] call f_fnc_mountGroups;";
-			id=1541;
+			id=3689;
 			type="Logic";
-			atlOffset=-5;
 		};
-		class Item444
+		class Item577
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1363.9072,0,1080.5378};
+				position[]={1377.0933,5,1773.8352};
 			};
 			name="F3_preMount_3IFB_8";
 			init="[synchronizedObjects this, [""Grp3IFB_CO""], true, false] call f_fnc_mountGroups;";
-			id=1542;
+			id=3690;
 			type="Logic";
-			atlOffset=-5;
 		};
-		class Item445
+		class Item578
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1365.365,0,1054.7144};
+				position[]={1378.551,5,1748.0117};
 			};
 			name="F3_preMount_3IFB_9";
 			init="[synchronizedObjects this, [""Grp3IFB_DC""], true, false] call f_fnc_mountGroups;";
-			id=1543;
+			id=3691;
 			type="Logic";
-			atlOffset=-5;
 		};
-		class Item446
+		class Item579
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1544.7996,6.6115026,1036.6387};
+				position[]={1557.9856,6.6115026,1729.936};
 			};
 			side="Empty";
 			flags=4;
@@ -39047,15 +50592,15 @@ class Mission
 				name="Veh3IFB_CAR4";
 				textures="Guerilla_07";
 			};
-			id=1544;
+			id=3692;
 			type="I_G_Offroad_01_F";
 		};
-		class Item447
+		class Item580
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1368.8815,6.6115026,1067.9521};
+				position[]={1382.0675,6.6115026,1761.2495};
 			};
 			side="Empty";
 			flags=4;
@@ -39066,15 +50611,15 @@ class Mission
 				name="Veh3IFB_CAR1";
 				textures="Guerilla_07";
 			};
-			id=1545;
+			id=3693;
 			type="I_G_Offroad_01_F";
 		};
-		class Item448
+		class Item581
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1368.9606,6.7971687,1045.4297};
+				position[]={1382.1466,6.7971687,1738.7271};
 			};
 			side="Empty";
 			flags=4;
@@ -39085,16 +50630,16 @@ class Mission
 				name="Veh3IFB_CAR2";
 				textures="Guerilla_07";
 			};
-			id=1546;
+			id=3694;
 			type="I_G_Offroad_01_F";
 			atlOffset=0.18566608;
 		};
-		class Item449
+		class Item582
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1544.0339,6.6115026,1059.2061};
+				position[]={1557.22,6.6115026,1752.5034};
 			};
 			side="Empty";
 			flags=4;
@@ -39105,15 +50650,15 @@ class Mission
 				name="Veh3IFB_CAR3";
 				textures="Guerilla_07";
 			};
-			id=1547;
+			id=3695;
 			type="I_G_Offroad_01_F";
 		};
-		class Item450
+		class Item583
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1410.2662,6.8716264,1082.0282};
+				position[]={1423.4523,6.8716264,1775.3257};
 			};
 			side="Empty";
 			flags=4;
@@ -39124,16 +50669,16 @@ class Mission
 				name="Veh3IFB_TR1";
 				textures="Guerilla_04";
 			};
-			id=1548;
+			id=3696;
 			type="I_G_Van_01_transport_F";
 			atlOffset=0.00011968613;
 		};
-		class Item451
+		class Item584
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1418.1637,6.8716264,1077.535};
+				position[]={1431.3497,6.8716264,1770.8325};
 			};
 			side="Empty";
 			flags=4;
@@ -39144,16 +50689,16 @@ class Mission
 				name="Veh3IFB_TR2";
 				textures="Guerilla_04";
 			};
-			id=1549;
+			id=3697;
 			type="I_G_Van_01_transport_F";
 			atlOffset=0.00011968613;
 		};
-		class Item452
+		class Item585
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1454.1765,6.8716264,1082.8163};
+				position[]={1467.3625,6.8716264,1776.1138};
 			};
 			side="Empty";
 			flags=4;
@@ -39164,16 +50709,16 @@ class Mission
 				name="Veh3IFB_TR3";
 				textures="Guerilla_04";
 			};
-			id=1550;
+			id=3698;
 			type="I_G_Van_01_transport_F";
 			atlOffset=0.00011968613;
 		};
-		class Item453
+		class Item586
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1464.2869,6.8716264,1077.66};
+				position[]={1477.4729,6.8716264,1770.9575};
 			};
 			side="Empty";
 			flags=4;
@@ -39184,16 +50729,16 @@ class Mission
 				name="Veh3IFB_TR4";
 				textures="Guerilla_04";
 			};
-			id=1557;
+			id=3699;
 			type="I_G_Van_01_transport_F";
 			atlOffset=0.00011968613;
 		};
-		class Item454
+		class Item587
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1494.6326,6.8716264,1082.662};
+				position[]={1507.8186,6.8716264,1775.9595};
 			};
 			side="Empty";
 			flags=4;
@@ -39204,16 +50749,16 @@ class Mission
 				name="Veh3IFB_TR5";
 				textures="Guerilla_04";
 			};
-			id=1558;
+			id=3700;
 			type="I_G_Van_01_transport_F";
 			atlOffset=0.00011968613;
 		};
-		class Item455
+		class Item588
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1503.4949,6.8716264,1077.1532};
+				position[]={1516.6809,6.8716264,1770.4507};
 			};
 			side="Empty";
 			flags=4;
@@ -39224,18 +50769,18 @@ class Mission
 				name="Veh3IFB_TR6";
 				textures="Guerilla_04";
 			};
-			id=1559;
+			id=3701;
 			type="I_G_Van_01_transport_F";
 			atlOffset=0.00011968613;
 		};
-		class Item456
+		class Item589
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1361.316,5.7177486,1039.123};
+				position[]={1374.5021,5.7177486,1732.4204};
 			};
-			id=1535;
+			id=3702;
 			type="SupportProvider_Virtual_CAS_Heli";
 			atlOffset=0.71774864;
 			class CustomAttributes
@@ -39319,14 +50864,14 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item457
+		class Item590
 		{
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={1360.1705,5.4597912,1062.4004};
+				position[]={1373.3566,5.4597912,1755.6978};
 			};
-			id=1536;
+			id=3703;
 			type="SupportProvider_Virtual_CAS_Heli";
 			atlOffset=0.45979118;
 			class CustomAttributes
@@ -39410,12 +50955,12 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item458
+		class Item591
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1378.1918,7.1644082,983.26599};
+				position[]={1391.3781,7.1644082,1676.5632};
 			};
 			side="Independent";
 			flags=6;
@@ -39426,15 +50971,15 @@ class Mission
 				name="Veh3IFB_IFV1";
 				textures="Guerilla_07";
 			};
-			id=1652;
+			id=3704;
 			type="I_G_Offroad_01_armed_F";
 		};
-		class Item459
+		class Item592
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1412.9154,7.1644082,983.18298};
+				position[]={1426.101,7.1644082,1676.4802};
 			};
 			side="Independent";
 			flags=6;
@@ -39445,7 +50990,7 @@ class Mission
 				name="Veh3IFB_IFV2";
 				textures="Guerilla_07";
 			};
-			id=1655;
+			id=3705;
 			type="I_G_Offroad_01_armed_F";
 		};
 	};
@@ -39453,16 +50998,16 @@ class Mission
 	{
 		class LinkIDProvider
 		{
-			nextID=99;
+			nextID=126;
 		};
 		class Links
 		{
-			items=99;
+			items=126;
 			class Item0
 			{
 				linkID=0;
-				item0=813;
-				item1=110;
+				item0=2199;
+				item1=2073;
 				class CustomData
 				{
 					type="Sync";
@@ -39471,8 +51016,8 @@ class Mission
 			class Item1
 			{
 				linkID=1;
-				item0=804;
-				item1=110;
+				item0=2196;
+				item1=2073;
 				class CustomData
 				{
 					type="Sync";
@@ -39481,8 +51026,8 @@ class Mission
 			class Item2
 			{
 				linkID=2;
-				item0=192;
-				item1=110;
+				item0=2091;
+				item1=2073;
 				class CustomData
 				{
 					type="Sync";
@@ -39491,8 +51036,8 @@ class Mission
 			class Item3
 			{
 				linkID=3;
-				item0=115;
-				item1=813;
+				item0=2075;
+				item1=2196;
 				class CustomData
 				{
 					type="Sync";
@@ -39501,8 +51046,8 @@ class Mission
 			class Item4
 			{
 				linkID=4;
-				item0=118;
-				item1=804;
+				item0=2198;
+				item1=2081;
 				class CustomData
 				{
 					type="Sync";
@@ -39511,8 +51056,8 @@ class Mission
 			class Item5
 			{
 				linkID=5;
-				item0=820;
-				item1=120;
+				item0=2197;
+				item1=2081;
 				class CustomData
 				{
 					type="Sync";
@@ -39521,8 +51066,8 @@ class Mission
 			class Item6
 			{
 				linkID=6;
-				item0=802;
-				item1=120;
+				item0=2096;
+				item1=2081;
 				class CustomData
 				{
 					type="Sync";
@@ -39531,8 +51076,8 @@ class Mission
 			class Item7
 			{
 				linkID=7;
-				item0=681;
-				item1=120;
+				item0=2083;
+				item1=2197;
 				class CustomData
 				{
 					type="Sync";
@@ -39541,8 +51086,8 @@ class Mission
 			class Item8
 			{
 				linkID=8;
-				item0=125;
-				item1=820;
+				item0=2057;
+				item1=2204;
 				class CustomData
 				{
 					type="Sync";
@@ -39551,8 +51096,8 @@ class Mission
 			class Item9
 			{
 				linkID=9;
-				item0=128;
-				item1=802;
+				item0=2056;
+				item1=2203;
 				class CustomData
 				{
 					type="Sync";
@@ -39561,8 +51106,8 @@ class Mission
 			class Item10
 			{
 				linkID=10;
-				item0=814;
-				item1=130;
+				item0=2053;
+				item1=2200;
 				class CustomData
 				{
 					type="Sync";
@@ -39571,8 +51116,8 @@ class Mission
 			class Item11
 			{
 				linkID=11;
-				item0=801;
-				item1=130;
+				item0=2054;
+				item1=2201;
 				class CustomData
 				{
 					type="Sync";
@@ -39581,8 +51126,8 @@ class Mission
 			class Item12
 			{
 				linkID=12;
-				item0=686;
-				item1=130;
+				item0=2055;
+				item1=2202;
 				class CustomData
 				{
 					type="Sync";
@@ -39591,8 +51136,8 @@ class Mission
 			class Item13
 			{
 				linkID=13;
-				item0=135;
-				item1=814;
+				item0=2388;
+				item1=2393;
 				class CustomData
 				{
 					type="Sync";
@@ -39601,8 +51146,8 @@ class Mission
 			class Item14
 			{
 				linkID=14;
-				item0=138;
-				item1=801;
+				item0=2536;
+				item1=2393;
 				class CustomData
 				{
 					type="Sync";
@@ -39611,8 +51156,8 @@ class Mission
 			class Item15
 			{
 				linkID=15;
-				item0=819;
-				item1=140;
+				item0=2410;
+				item1=2393;
 				class CustomData
 				{
 					type="Sync";
@@ -39621,8 +51166,8 @@ class Mission
 			class Item16
 			{
 				linkID=16;
-				item0=799;
-				item1=140;
+				item0=2519;
+				item1=2401;
 				class CustomData
 				{
 					type="Sync";
@@ -39631,8 +51176,8 @@ class Mission
 			class Item17
 			{
 				linkID=17;
-				item0=369;
-				item1=140;
+				item0=2535;
+				item1=2401;
 				class CustomData
 				{
 					type="Sync";
@@ -39641,8 +51186,8 @@ class Mission
 			class Item18
 			{
 				linkID=18;
-				item0=149;
-				item1=819;
+				item0=2416;
+				item1=2401;
 				class CustomData
 				{
 					type="Sync";
@@ -39651,8 +51196,8 @@ class Mission
 			class Item19
 			{
 				linkID=19;
-				item0=145;
-				item1=799;
+				item0=2529;
+				item1=2520;
 				class CustomData
 				{
 					type="Sync";
@@ -39661,8 +51206,8 @@ class Mission
 			class Item20
 			{
 				linkID=20;
-				item0=818;
-				item1=150;
+				item0=2530;
+				item1=2520;
 				class CustomData
 				{
 					type="Sync";
@@ -39671,8 +51216,8 @@ class Mission
 			class Item21
 			{
 				linkID=21;
-				item0=800;
-				item1=150;
+				item0=2526;
+				item1=2523;
 				class CustomData
 				{
 					type="Sync";
@@ -39681,8 +51226,8 @@ class Mission
 			class Item22
 			{
 				linkID=22;
-				item0=374;
-				item1=150;
+				item0=2531;
+				item1=2521;
 				class CustomData
 				{
 					type="Sync";
@@ -39691,8 +51236,8 @@ class Mission
 			class Item23
 			{
 				linkID=23;
-				item0=159;
-				item1=818;
+				item0=2532;
+				item1=2521;
 				class CustomData
 				{
 					type="Sync";
@@ -39701,8 +51246,8 @@ class Mission
 			class Item24
 			{
 				linkID=24;
-				item0=155;
-				item1=800;
+				item0=2533;
+				item1=2522;
 				class CustomData
 				{
 					type="Sync";
@@ -39711,8 +51256,8 @@ class Mission
 			class Item25
 			{
 				linkID=25;
-				item0=817;
-				item1=160;
+				item0=2534;
+				item1=2522;
 				class CustomData
 				{
 					type="Sync";
@@ -39721,8 +51266,8 @@ class Mission
 			class Item26
 			{
 				linkID=26;
-				item0=797;
-				item1=160;
+				item0=2527;
+				item1=2524;
 				class CustomData
 				{
 					type="Sync";
@@ -39731,8 +51276,8 @@ class Mission
 			class Item27
 			{
 				linkID=27;
-				item0=532;
-				item1=160;
+				item0=3324;
+				item1=2645;
 				class CustomData
 				{
 					type="Sync";
@@ -39741,8 +51286,8 @@ class Mission
 			class Item28
 			{
 				linkID=28;
-				item0=169;
-				item1=817;
+				item0=3323;
+				item1=2645;
 				class CustomData
 				{
 					type="Sync";
@@ -39751,8 +51296,8 @@ class Mission
 			class Item29
 			{
 				linkID=29;
-				item0=165;
-				item1=797;
+				item0=2711;
+				item1=2645;
 				class CustomData
 				{
 					type="Sync";
@@ -39761,8 +51306,8 @@ class Mission
 			class Item30
 			{
 				linkID=30;
-				item0=816;
-				item1=170;
+				item0=2647;
+				item1=3324;
 				class CustomData
 				{
 					type="Sync";
@@ -39771,8 +51316,8 @@ class Mission
 			class Item31
 			{
 				linkID=31;
-				item0=798;
-				item1=170;
+				item0=2650;
+				item1=3323;
 				class CustomData
 				{
 					type="Sync";
@@ -39781,8 +51326,8 @@ class Mission
 			class Item32
 			{
 				linkID=32;
-				item0=537;
-				item1=170;
+				item0=3331;
+				item1=2653;
 				class CustomData
 				{
 					type="Sync";
@@ -39791,8 +51336,8 @@ class Mission
 			class Item33
 			{
 				linkID=33;
-				item0=179;
-				item1=816;
+				item0=3321;
+				item1=2653;
 				class CustomData
 				{
 					type="Sync";
@@ -39801,8 +51346,8 @@ class Mission
 			class Item34
 			{
 				linkID=34;
-				item0=175;
-				item1=798;
+				item0=3199;
+				item1=2653;
 				class CustomData
 				{
 					type="Sync";
@@ -39811,8 +51356,8 @@ class Mission
 			class Item35
 			{
 				linkID=35;
-				item0=815;
-				item1=180;
+				item0=2655;
+				item1=3331;
 				class CustomData
 				{
 					type="Sync";
@@ -39821,8 +51366,8 @@ class Mission
 			class Item36
 			{
 				linkID=36;
-				item0=803;
-				item1=180;
+				item0=2658;
+				item1=3321;
 				class CustomData
 				{
 					type="Sync";
@@ -39831,8 +51376,8 @@ class Mission
 			class Item37
 			{
 				linkID=37;
-				item0=197;
-				item1=180;
+				item0=3325;
+				item1=2661;
 				class CustomData
 				{
 					type="Sync";
@@ -39841,8 +51386,8 @@ class Mission
 			class Item38
 			{
 				linkID=38;
-				item0=185;
-				item1=815;
+				item0=3320;
+				item1=2661;
 				class CustomData
 				{
 					type="Sync";
@@ -39851,8 +51396,8 @@ class Mission
 			class Item39
 			{
 				linkID=39;
-				item0=188;
-				item1=803;
+				item0=3204;
+				item1=2661;
 				class CustomData
 				{
 					type="Sync";
@@ -39861,8 +51406,8 @@ class Mission
 			class Item40
 			{
 				linkID=40;
-				item0=973;
-				item1=964;
+				item0=2663;
+				item1=3325;
 				class CustomData
 				{
 					type="Sync";
@@ -39871,8 +51416,8 @@ class Mission
 			class Item41
 			{
 				linkID=41;
-				item0=972;
-				item1=964;
+				item0=2666;
+				item1=3320;
 				class CustomData
 				{
 					type="Sync";
@@ -39881,8 +51426,8 @@ class Mission
 			class Item42
 			{
 				linkID=42;
-				item0=970;
-				item1=973;
+				item0=3330;
+				item1=2669;
 				class CustomData
 				{
 					type="Sync";
@@ -39891,8 +51436,8 @@ class Mission
 			class Item43
 			{
 				linkID=43;
-				item0=966;
-				item1=972;
+				item0=3318;
+				item1=2669;
 				class CustomData
 				{
 					type="Sync";
@@ -39901,8 +51446,8 @@ class Mission
 			class Item44
 			{
 				linkID=44;
-				item0=983;
-				item1=974;
+				item0=2889;
+				item1=2669;
 				class CustomData
 				{
 					type="Sync";
@@ -39911,8 +51456,8 @@ class Mission
 			class Item45
 			{
 				linkID=45;
-				item0=982;
-				item1=974;
+				item0=2675;
+				item1=3330;
 				class CustomData
 				{
 					type="Sync";
@@ -39921,8 +51466,8 @@ class Mission
 			class Item46
 			{
 				linkID=46;
-				item0=980;
-				item1=983;
+				item0=2671;
+				item1=3318;
 				class CustomData
 				{
 					type="Sync";
@@ -39931,8 +51476,8 @@ class Mission
 			class Item47
 			{
 				linkID=47;
-				item0=976;
-				item1=982;
+				item0=3329;
+				item1=2677;
 				class CustomData
 				{
 					type="Sync";
@@ -39941,8 +51486,8 @@ class Mission
 			class Item48
 			{
 				linkID=48;
-				item0=824;
-				item1=964;
+				item0=3319;
+				item1=2677;
 				class CustomData
 				{
 					type="Sync";
@@ -39951,8 +51496,8 @@ class Mission
 			class Item49
 			{
 				linkID=49;
-				item0=839;
-				item1=974;
+				item0=2894;
+				item1=2677;
 				class CustomData
 				{
 					type="Sync";
@@ -39961,8 +51506,8 @@ class Mission
 			class Item50
 			{
 				linkID=50;
-				item0=54;
-				item1=1099;
+				item0=2683;
+				item1=3329;
 				class CustomData
 				{
 					type="Sync";
@@ -39971,8 +51516,8 @@ class Mission
 			class Item51
 			{
 				linkID=51;
-				item0=55;
-				item1=1099;
+				item0=2679;
+				item1=3319;
 				class CustomData
 				{
 					type="Sync";
@@ -39981,8 +51526,8 @@ class Mission
 			class Item52
 			{
 				linkID=52;
-				item0=51;
-				item1=1107;
+				item0=3328;
+				item1=2685;
 				class CustomData
 				{
 					type="Sync";
@@ -39991,8 +51536,8 @@ class Mission
 			class Item53
 			{
 				linkID=53;
-				item0=56;
-				item1=1105;
+				item0=3316;
+				item1=2685;
 				class CustomData
 				{
 					type="Sync";
@@ -40001,8 +51546,8 @@ class Mission
 			class Item54
 			{
 				linkID=54;
-				item0=87;
-				item1=1105;
+				item0=3049;
+				item1=2685;
 				class CustomData
 				{
 					type="Sync";
@@ -40011,8 +51556,8 @@ class Mission
 			class Item55
 			{
 				linkID=55;
-				item0=88;
-				item1=1106;
+				item0=2691;
+				item1=3328;
 				class CustomData
 				{
 					type="Sync";
@@ -40021,8 +51566,8 @@ class Mission
 			class Item56
 			{
 				linkID=56;
-				item0=89;
-				item1=1106;
+				item0=2687;
+				item1=3316;
 				class CustomData
 				{
 					type="Sync";
@@ -40031,8 +51576,8 @@ class Mission
 			class Item57
 			{
 				linkID=57;
-				item0=52;
-				item1=1108;
+				item0=3327;
+				item1=2693;
 				class CustomData
 				{
 					type="Sync";
@@ -40041,8 +51586,8 @@ class Mission
 			class Item58
 			{
 				linkID=58;
-				item0=59;
-				item1=1119;
+				item0=3317;
+				item1=2693;
 				class CustomData
 				{
 					type="Sync";
@@ -40051,8 +51596,8 @@ class Mission
 			class Item59
 			{
 				linkID=59;
-				item0=42;
-				item1=1118;
+				item0=3054;
+				item1=2693;
 				class CustomData
 				{
 					type="Sync";
@@ -40061,8 +51606,8 @@ class Mission
 			class Item60
 			{
 				linkID=60;
-				item0=43;
-				item1=1115;
+				item0=2699;
+				item1=3327;
 				class CustomData
 				{
 					type="Sync";
@@ -40071,8 +51616,8 @@ class Mission
 			class Item61
 			{
 				linkID=61;
-				item0=44;
-				item1=1116;
+				item0=2695;
+				item1=3317;
 				class CustomData
 				{
 					type="Sync";
@@ -40081,8 +51626,8 @@ class Mission
 			class Item62
 			{
 				linkID=62;
-				item0=45;
-				item1=1117;
+				item0=3326;
+				item1=2701;
 				class CustomData
 				{
 					type="Sync";
@@ -40091,8 +51636,8 @@ class Mission
 			class Item63
 			{
 				linkID=63;
-				item0=57;
-				item1=1114;
+				item0=3322;
+				item1=2701;
 				class CustomData
 				{
 					type="Sync";
@@ -40101,8 +51646,8 @@ class Mission
 			class Item64
 			{
 				linkID=64;
-				item0=41;
-				item1=1113;
+				item0=2716;
+				item1=2701;
 				class CustomData
 				{
 					type="Sync";
@@ -40111,8 +51656,8 @@ class Mission
 			class Item65
 			{
 				linkID=65;
-				item0=38;
-				item1=1110;
+				item0=2703;
+				item1=3326;
 				class CustomData
 				{
 					type="Sync";
@@ -40121,8 +51666,8 @@ class Mission
 			class Item66
 			{
 				linkID=66;
-				item0=39;
-				item1=1111;
+				item0=2706;
+				item1=3322;
 				class CustomData
 				{
 					type="Sync";
@@ -40131,8 +51676,8 @@ class Mission
 			class Item67
 			{
 				linkID=67;
-				item0=40;
-				item1=1112;
+				item0=3467;
+				item1=3458;
 				class CustomData
 				{
 					type="Sync";
@@ -40141,8 +51686,8 @@ class Mission
 			class Item68
 			{
 				linkID=68;
-				item0=952;
-				item1=1124;
+				item0=3466;
+				item1=3458;
 				class CustomData
 				{
 					type="Sync";
@@ -40151,8 +51696,8 @@ class Mission
 			class Item69
 			{
 				linkID=69;
-				item0=951;
-				item1=1123;
+				item0=3464;
+				item1=3467;
 				class CustomData
 				{
 					type="Sync";
@@ -40161,8 +51706,8 @@ class Mission
 			class Item70
 			{
 				linkID=70;
-				item0=953;
-				item1=1120;
+				item0=3460;
+				item1=3466;
 				class CustomData
 				{
 					type="Sync";
@@ -40171,8 +51716,8 @@ class Mission
 			class Item71
 			{
 				linkID=71;
-				item0=954;
-				item1=1120;
+				item0=3477;
+				item1=3468;
 				class CustomData
 				{
 					type="Sync";
@@ -40181,8 +51726,8 @@ class Mission
 			class Item72
 			{
 				linkID=72;
-				item0=955;
-				item1=1121;
+				item0=3476;
+				item1=3468;
 				class CustomData
 				{
 					type="Sync";
@@ -40191,8 +51736,8 @@ class Mission
 			class Item73
 			{
 				linkID=73;
-				item0=956;
-				item1=1121;
+				item0=3474;
+				item1=3477;
 				class CustomData
 				{
 					type="Sync";
@@ -40201,8 +51746,8 @@ class Mission
 			class Item74
 			{
 				linkID=74;
-				item0=957;
-				item1=1122;
+				item0=3470;
+				item1=3476;
 				class CustomData
 				{
 					type="Sync";
@@ -40211,8 +51756,8 @@ class Mission
 			class Item75
 			{
 				linkID=75;
-				item0=958;
-				item1=1122;
+				item0=3334;
+				item1=3458;
 				class CustomData
 				{
 					type="Sync";
@@ -40221,8 +51766,8 @@ class Mission
 			class Item76
 			{
 				linkID=76;
-				item0=58;
-				item1=1129;
+				item0=3339;
+				item1=3468;
 				class CustomData
 				{
 					type="Sync";
@@ -40231,8 +51776,8 @@ class Mission
 			class Item77
 			{
 				linkID=77;
-				item0=46;
-				item1=1128;
+				item0=2605;
+				item1=3516;
 				class CustomData
 				{
 					type="Sync";
@@ -40241,8 +51786,8 @@ class Mission
 			class Item78
 			{
 				linkID=78;
-				item0=47;
-				item1=1125;
+				item0=2606;
+				item1=3516;
 				class CustomData
 				{
 					type="Sync";
@@ -40251,8 +51796,8 @@ class Mission
 			class Item79
 			{
 				linkID=79;
-				item0=48;
-				item1=1126;
+				item0=2602;
+				item1=3519;
 				class CustomData
 				{
 					type="Sync";
@@ -40261,8 +51806,8 @@ class Mission
 			class Item80
 			{
 				linkID=80;
-				item0=49;
-				item1=1127;
+				item0=2607;
+				item1=3517;
 				class CustomData
 				{
 					type="Sync";
@@ -40271,8 +51816,8 @@ class Mission
 			class Item81
 			{
 				linkID=81;
-				item0=1538;
-				item1=1417;
+				item0=2638;
+				item1=3517;
 				class CustomData
 				{
 					type="Sync";
@@ -40281,8 +51826,8 @@ class Mission
 			class Item82
 			{
 				linkID=82;
-				item0=1536;
-				item1=1417;
+				item0=2639;
+				item1=3518;
 				class CustomData
 				{
 					type="Sync";
@@ -40291,8 +51836,8 @@ class Mission
 			class Item83
 			{
 				linkID=83;
-				item0=1561;
-				item1=1417;
+				item0=2640;
+				item1=3518;
 				class CustomData
 				{
 					type="Sync";
@@ -40301,8 +51846,8 @@ class Mission
 			class Item84
 			{
 				linkID=84;
-				item0=1419;
-				item1=1538;
+				item0=2603;
+				item1=3520;
 				class CustomData
 				{
 					type="Sync";
@@ -40311,8 +51856,8 @@ class Mission
 			class Item85
 			{
 				linkID=85;
-				item0=1422;
-				item1=1536;
+				item0=2610;
+				item1=3530;
 				class CustomData
 				{
 					type="Sync";
@@ -40321,8 +51866,8 @@ class Mission
 			class Item86
 			{
 				linkID=86;
-				item0=1537;
-				item1=1425;
+				item0=2593;
+				item1=3529;
 				class CustomData
 				{
 					type="Sync";
@@ -40331,8 +51876,8 @@ class Mission
 			class Item87
 			{
 				linkID=87;
-				item0=1535;
-				item1=1425;
+				item0=2594;
+				item1=3526;
 				class CustomData
 				{
 					type="Sync";
@@ -40341,8 +51886,8 @@ class Mission
 			class Item88
 			{
 				linkID=88;
-				item0=1565;
-				item1=1425;
+				item0=2595;
+				item1=3527;
 				class CustomData
 				{
 					type="Sync";
@@ -40351,8 +51896,8 @@ class Mission
 			class Item89
 			{
 				linkID=89;
-				item0=1427;
-				item1=1537;
+				item0=2596;
+				item1=3528;
 				class CustomData
 				{
 					type="Sync";
@@ -40361,8 +51906,8 @@ class Mission
 			class Item90
 			{
 				linkID=90;
-				item0=1430;
-				item1=1535;
+				item0=2608;
+				item1=3525;
 				class CustomData
 				{
 					type="Sync";
@@ -40371,8 +51916,8 @@ class Mission
 			class Item91
 			{
 				linkID=91;
-				item0=1548;
-				item1=1539;
+				item0=2592;
+				item1=3524;
 				class CustomData
 				{
 					type="Sync";
@@ -40381,8 +51926,8 @@ class Mission
 			class Item92
 			{
 				linkID=92;
-				item0=1549;
-				item1=1539;
+				item0=2589;
+				item1=3521;
 				class CustomData
 				{
 					type="Sync";
@@ -40391,8 +51936,8 @@ class Mission
 			class Item93
 			{
 				linkID=93;
-				item0=1545;
-				item1=1542;
+				item0=2590;
+				item1=3522;
 				class CustomData
 				{
 					type="Sync";
@@ -40401,8 +51946,8 @@ class Mission
 			class Item94
 			{
 				linkID=94;
-				item0=1550;
-				item1=1540;
+				item0=2591;
+				item1=3523;
 				class CustomData
 				{
 					type="Sync";
@@ -40411,8 +51956,8 @@ class Mission
 			class Item95
 			{
 				linkID=95;
-				item0=1557;
-				item1=1540;
+				item0=3446;
+				item1=3535;
 				class CustomData
 				{
 					type="Sync";
@@ -40421,8 +51966,8 @@ class Mission
 			class Item96
 			{
 				linkID=96;
-				item0=1558;
-				item1=1541;
+				item0=3445;
+				item1=3534;
 				class CustomData
 				{
 					type="Sync";
@@ -40431,8 +51976,8 @@ class Mission
 			class Item97
 			{
 				linkID=97;
-				item0=1559;
-				item1=1541;
+				item0=3447;
+				item1=3531;
 				class CustomData
 				{
 					type="Sync";
@@ -40441,8 +51986,278 @@ class Mission
 			class Item98
 			{
 				linkID=98;
-				item0=1546;
-				item1=1543;
+				item0=3448;
+				item1=3531;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item99
+			{
+				linkID=99;
+				item0=3449;
+				item1=3532;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item100
+			{
+				linkID=100;
+				item0=3450;
+				item1=3532;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item101
+			{
+				linkID=101;
+				item0=3451;
+				item1=3533;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item102
+			{
+				linkID=102;
+				item0=3452;
+				item1=3533;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item103
+			{
+				linkID=103;
+				item0=2609;
+				item1=3540;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item104
+			{
+				linkID=104;
+				item0=2597;
+				item1=3539;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item105
+			{
+				linkID=105;
+				item0=2598;
+				item1=3536;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item106
+			{
+				linkID=106;
+				item0=2599;
+				item1=3537;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item107
+			{
+				linkID=107;
+				item0=2600;
+				item1=3538;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item108
+			{
+				linkID=108;
+				item0=3557;
+				item1=3559;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item109
+			{
+				linkID=109;
+				item0=3703;
+				item1=3559;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item110
+			{
+				linkID=110;
+				item0=3577;
+				item1=3559;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item111
+			{
+				linkID=111;
+				item0=3561;
+				item1=3557;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item112
+			{
+				linkID=112;
+				item0=3564;
+				item1=3703;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item113
+			{
+				linkID=113;
+				item0=3683;
+				item1=3567;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item114
+			{
+				linkID=114;
+				item0=3702;
+				item1=3567;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item115
+			{
+				linkID=115;
+				item0=3582;
+				item1=3567;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item116
+			{
+				linkID=116;
+				item0=3569;
+				item1=3683;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item117
+			{
+				linkID=117;
+				item0=3572;
+				item1=3702;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item118
+			{
+				linkID=118;
+				item0=3696;
+				item1=3687;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item119
+			{
+				linkID=119;
+				item0=3697;
+				item1=3687;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item120
+			{
+				linkID=120;
+				item0=3693;
+				item1=3690;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item121
+			{
+				linkID=121;
+				item0=3698;
+				item1=3688;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item122
+			{
+				linkID=122;
+				item0=3699;
+				item1=3688;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item123
+			{
+				linkID=123;
+				item0=3700;
+				item1=3689;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item124
+			{
+				linkID=124;
+				item0=3701;
+				item1=3689;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item125
+			{
+				linkID=125;
+				item0=3694;
+				item1=3691;
 				class CustomData
 				{
 					type="Sync";


### PR DESCRIPTION
This changes CSAT vests from LBV harnesses to tac vests in accordance with #301. It also adds comments providing the LBV harness classnames, with a reminder to use them if the intention is to use assignGear AI for CSAT enemies.