### PR TITLE
301 CSAT tac vests

### DIFF
--- a/f/assignGear/f_assignGear_csat.sqf
+++ b/f/assignGear/f_assignGear_csat.sqf
@@ -279,12 +279,14 @@ _baseGlasses = [];
 //_baseHelmet = ["H_HelmetO_oucamo"];
 
 // Vests
-_lightRig = ["V_HarnessO_brn"];
-_standardRig = ["V_HarnessO_brn"];
+_lightRig = ["V_TacVest_khk"];
+_standardRig = ["V_TacVest_khk"];
+// Consider changing to "V_HarnessO_brn" if using this with assignGear AI.
 
 // Urban Vests
-// _lightRig = ["V_HarnessO_gry"];
-// _standardRig = ["V_HarnessO_gry"];
+// _lightRig = ["V_TacVest_blk"];
+// _standardRig = ["V_TacVest_blk"];
+// Consider changing to "V_HarnessO_gry" if using this with assignGear AI.
 
 // Diver
 _diverUniform =  ["U_O_Wetsuit"];

--- a/f/assignGear/f_assignGear_csatPacific.sqf
+++ b/f/assignGear/f_assignGear_csatPacific.sqf
@@ -279,8 +279,14 @@ _baseGlasses = [];
 //_baseHelmet = ["H_HelmetO_oucamo"];
 
 // Vests
-_lightRig = ["V_HarnessO_ghex_F"];
-_standardRig = ["V_HarnessO_ghex_F"];
+_lightRig = ["V_TacVest_oli"];
+_standardRig = ["V_TacVest_oli"];
+// Consider changing to "V_HarnessO_ghex_F" if using this with assignGear AI.
+
+// Urban Vests
+// _lightRig = ["V_TacVest_blk"];
+// _standardRig = ["V_TacVest_blk"];
+// Consider changing to "V_HarnessO_gry" if using this with assignGear AI.
 
 // Diver
 _diverUniform =  ["U_O_Wetsuit"];


### PR DESCRIPTION
In accordance with #301, this PR changes CSAT LBV harnesses to tac vests. It also provides the LBV classnames in a comment with instructions to use them if using assignGear AI for CSAT enemies.