### PR TITLE
290 light vehicle crews

### DIFF
--- a/f/assignGear/f_assignGear_3IFB.sqf
+++ b/f/assignGear/f_assignGear_3IFB.sqf
@@ -34,6 +34,8 @@
 //		hsamag		- heavy SAM assistant gunner (deployable)
 //		sn			- sniper
 //		sp			- spotter (for sniper)
+//		lvc			- light vehicle crew
+//		lvd			- light vehicle driver (repair)
 //		vc			- vehicle commander
 //		vg			- vehicle gunner
 //		vd			- vehicle driver (repair)

--- a/f/assignGear/f_assignGear_3IFB_standard.sqf
+++ b/f/assignGear/f_assignGear_3IFB_standard.sqf
@@ -423,6 +423,29 @@ switch (_typeofUnit) do
 		_unit addWeapon "Rangefinder";
 		_unit addmagazines [_SNrifleMag, 2];
 	};
+// Light Vehicle Crew Loadout:
+	case "lvc":
+	{
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addweapon _binoculars;
+	};
+// Light Vehicle Driver Loadout:
+	case "lvd":
+	{
+		_unit setUnitTrait ["engineer",true]; // Can repair
+		_unit addBackpack _bag;
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addItem "ToolKit";
+		_unit addweapon _binoculars;
+	};
 // Vehicle Commander Loadout:
 	case "vc":
 	{

--- a/f/assignGear/f_assignGear_aaf.sqf
+++ b/f/assignGear/f_assignGear_aaf.sqf
@@ -34,6 +34,8 @@
 //		hsamag		- heavy SAM assistant gunner (deployable)
 //		sn			- sniper
 //		sp			- spotter (for sniper)
+//		lvc			- light vehicle crew
+//		lvd			- light vehicle driver (repair)
 //		vc			- vehicle commander
 //		vg			- vehicle gunner
 //		vd			- vehicle driver (repair)

--- a/f/assignGear/f_assignGear_aaf_standard.sqf
+++ b/f/assignGear/f_assignGear_aaf_standard.sqf
@@ -423,6 +423,29 @@ switch (_typeofUnit) do
 		_unit addWeapon "Rangefinder";
 		_unit addmagazines [_SNrifleMag, 3];
 	};
+// Light Vehicle Crew Loadout:
+	case "lvc":
+	{
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addweapon _binoculars;
+	};
+// Light Vehicle Driver Loadout:
+	case "lvd":
+	{
+		_unit setUnitTrait ["engineer",true]; // Can repair
+		_unit addBackpack _bag;
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addItem "ToolKit";
+		_unit addweapon _binoculars;
+	};
 // Vehicle Commander Loadout:
 	case "vc":
 	{

--- a/f/assignGear/f_assignGear_csat.sqf
+++ b/f/assignGear/f_assignGear_csat.sqf
@@ -34,6 +34,8 @@
 //		hsamag		- heavy SAM assistant gunner (deployable)
 //		sn			- sniper
 //		sp			- spotter (for sniper)
+//		lvc			- light vehicle crew
+//		lvd			- light vehicle driver (repair)
 //		vc			- vehicle commander
 //		vg			- vehicle gunner
 //		vd			- vehicle driver (repair)

--- a/f/assignGear/f_assignGear_csatPacific.sqf
+++ b/f/assignGear/f_assignGear_csatPacific.sqf
@@ -34,6 +34,8 @@
 //		hsamag		- heavy SAM assistant gunner (deployable)
 //		sn			- sniper
 //		sp			- spotter (for sniper)
+//		lvc			- light vehicle crew
+//		lvd			- light vehicle driver (repair)
 //		vc			- vehicle commander
 //		vg			- vehicle gunner
 //		vd			- vehicle driver (repair)

--- a/f/assignGear/f_assignGear_csatPacific_standard.sqf
+++ b/f/assignGear/f_assignGear_csatPacific_standard.sqf
@@ -423,6 +423,29 @@ switch (_typeofUnit) do
 		_unit addWeapon "Rangefinder";
 		_unit addmagazines [_SNrifleMag, 3];
 	};
+// Light Vehicle Crew Loadout:
+	case "lvc":
+	{
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addweapon _binoculars;
+	};
+// Light Vehicle Driver Loadout:
+	case "lvd":
+	{
+		_unit setUnitTrait ["engineer",true]; // Can repair
+		_unit addBackpack _bag;
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addItem "ToolKit";
+		_unit addweapon _binoculars;
+	};
 // Vehicle Commander Loadout:
 	case "vc":
 	{

--- a/f/assignGear/f_assignGear_csat_standard.sqf
+++ b/f/assignGear/f_assignGear_csat_standard.sqf
@@ -423,6 +423,29 @@ switch (_typeofUnit) do
 		_unit addWeapon "Rangefinder";
 		_unit addmagazines [_SNrifleMag, 3];
 	};
+// Light Vehicle Crew Loadout:
+	case "lvc":
+	{
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addweapon _binoculars;
+	};
+// Light Vehicle Driver Loadout:
+	case "lvd":
+	{
+		_unit setUnitTrait ["engineer",true]; // Can repair
+		_unit addBackpack _bag;
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addItem "ToolKit";
+		_unit addweapon _binoculars;
+	};
 // Vehicle Commander Loadout:
 	case "vc":
 	{

--- a/f/assignGear/f_assignGear_ctrg.sqf
+++ b/f/assignGear/f_assignGear_ctrg.sqf
@@ -34,6 +34,8 @@
 //		hsamag		- heavy SAM assistant gunner (deployable)
 //		sn			- sniper
 //		sp			- spotter (for sniper)
+//		lvc			- light vehicle crew
+//		lvd			- light vehicle driver (repair)
 //		vc			- vehicle commander
 //		vg			- vehicle gunner
 //		vd			- vehicle driver (repair)

--- a/f/assignGear/f_assignGear_ctrg_standard.sqf
+++ b/f/assignGear/f_assignGear_ctrg_standard.sqf
@@ -430,6 +430,29 @@ switch (_typeofUnit) do
 		_unit addmagazines [_smgmag, 4];
 		_unit addweapon "Rangefinder";
 	};
+// Light Vehicle Crew Loadout:
+	case "lvc":
+	{
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addweapon _binoculars;
+	};
+// Light Vehicle Driver Loadout:
+	case "lvd":
+	{
+		_unit setUnitTrait ["engineer",true]; // Can repair
+		_unit addBackpack _bag;
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addItem "ToolKit";
+		_unit addweapon _binoculars;
+	};
 // Vehicle Gunner Loadout:
 	case "vg":
 	{

--- a/f/assignGear/f_assignGear_fia.sqf
+++ b/f/assignGear/f_assignGear_fia.sqf
@@ -34,6 +34,8 @@
 //		hsamag		- heavy SAM assistant gunner (deployable)
 //		sn			- sniper
 //		sp			- spotter (for sniper)
+//		lvc			- light vehicle crew
+//		lvd			- light vehicle driver (repair)
 //		vc			- vehicle commander
 //		vg			- vehicle gunner
 //		vd			- vehicle driver (repair)

--- a/f/assignGear/f_assignGear_fia_standard.sqf
+++ b/f/assignGear/f_assignGear_fia_standard.sqf
@@ -420,6 +420,29 @@ switch (_typeofUnit) do
 		_unit addWeapon "Rangefinder";
 		_unit addmagazines [_SNrifleMag, 3];
 	};
+// Light Vehicle Crew Loadout:
+	case "lvc":
+	{
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addweapon _binoculars;
+	};
+// Light Vehicle Driver Loadout:
+	case "lvd":
+	{
+		_unit setUnitTrait ["engineer",true]; // Can repair
+		_unit addBackpack _bag;
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addItem "ToolKit";
+		_unit addweapon _binoculars;
+	};
 // Vehicle Commander Loadout:
 	case "vc":
 	{

--- a/f/assignGear/f_assignGear_ldf.sqf
+++ b/f/assignGear/f_assignGear_ldf.sqf
@@ -34,6 +34,8 @@
 //		hsamag		- heavy SAM assistant gunner (deployable)
 //		sn			- sniper
 //		sp			- spotter (for sniper)
+//		lvc			- light vehicle crew
+//		lvd			- light vehicle driver (repair)
 //		vc			- vehicle commander
 //		vg			- vehicle gunner
 //		vd			- vehicle driver (repair)

--- a/f/assignGear/f_assignGear_ldf_standard.sqf
+++ b/f/assignGear/f_assignGear_ldf_standard.sqf
@@ -423,6 +423,29 @@ switch (_typeofUnit) do
 		_unit addWeapon "Rangefinder";
 		_unit addmagazines [_SNrifleMag, 3];
 	};
+// Light Vehicle Crew Loadout:
+	case "lvc":
+	{
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addweapon _binoculars;
+	};
+// Light Vehicle Driver Loadout:
+	case "lvd":
+	{
+		_unit setUnitTrait ["engineer",true]; // Can repair
+		_unit addBackpack _bag;
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addItem "ToolKit";
+		_unit addweapon _binoculars;
+	};
 // Vehicle Commander Loadout:
 	case "vc":
 	{

--- a/f/assignGear/f_assignGear_nato.sqf
+++ b/f/assignGear/f_assignGear_nato.sqf
@@ -34,6 +34,8 @@
 //		hsamag		- heavy SAM assistant gunner (deployable)
 //		sn			- sniper
 //		sp			- spotter (for sniper)
+//		lvc			- light vehicle crew
+//		lvd			- light vehicle driver (repair)
 //		vc			- vehicle commander
 //		vg			- vehicle gunner
 //		vd			- vehicle driver (repair)

--- a/f/assignGear/f_assignGear_natoPacific.sqf
+++ b/f/assignGear/f_assignGear_natoPacific.sqf
@@ -34,6 +34,8 @@
 //		hsamag		- heavy SAM assistant gunner (deployable)
 //		sn			- sniper
 //		sp			- spotter (for sniper)
+//		lvc			- light vehicle crew
+//		lvd			- light vehicle driver (repair)
 //		vc			- vehicle commander
 //		vg			- vehicle gunner
 //		vd			- vehicle driver (repair)

--- a/f/assignGear/f_assignGear_natoPacific_standard.sqf
+++ b/f/assignGear/f_assignGear_natoPacific_standard.sqf
@@ -433,6 +433,29 @@ switch (_typeofUnit) do
 		_unit addmagazines [_smgmag, 4];
 		_unit addweapon "Rangefinder";
 	};
+// Light Vehicle Crew Loadout:
+	case "lvc":
+	{
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addweapon _binoculars;
+	};
+// Light Vehicle Driver Loadout:
+	case "lvd":
+	{
+		_unit setUnitTrait ["engineer",true]; // Can repair
+		_unit addBackpack _bag;
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addItem "ToolKit";
+		_unit addweapon _binoculars;
+	};
 // Vehicle Gunner Loadout:
 	case "vg":
 	{

--- a/f/assignGear/f_assignGear_natoWoodland.sqf
+++ b/f/assignGear/f_assignGear_natoWoodland.sqf
@@ -34,6 +34,8 @@
 //		hsamag		- heavy SAM assistant gunner (deployable)
 //		sn			- sniper
 //		sp			- spotter (for sniper)
+//		lvc			- light vehicle crew
+//		lvd			- light vehicle driver (repair)
 //		vc			- vehicle commander
 //		vg			- vehicle gunner
 //		vd			- vehicle driver (repair)

--- a/f/assignGear/f_assignGear_natoWoodland_standard.sqf
+++ b/f/assignGear/f_assignGear_natoWoodland_standard.sqf
@@ -423,6 +423,29 @@ switch (_typeofUnit) do
 		_unit addWeapon "Rangefinder";
 		_unit addmagazines [_SNrifleMag, 3];
 	};
+// Light Vehicle Crew Loadout:
+	case "lvc":
+	{
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addweapon _binoculars;
+	};
+// Light Vehicle Driver Loadout:
+	case "lvd":
+	{
+		_unit setUnitTrait ["engineer",true]; // Can repair
+		_unit addBackpack _bag;
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addItem "ToolKit";
+		_unit addweapon _binoculars;
+	};
 // Vehicle Commander Loadout:
 	case "vc":
 	{

--- a/f/assignGear/f_assignGear_nato_standard.sqf
+++ b/f/assignGear/f_assignGear_nato_standard.sqf
@@ -423,6 +423,29 @@ switch (_typeofUnit) do
 		_unit addWeapon "Rangefinder";
 		_unit addmagazines [_SNrifleMag, 3];
 	};
+// Light Vehicle Crew Loadout:
+	case "lvc":
+	{
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addweapon _binoculars;
+	};
+// Light Vehicle Driver Loadout:
+	case "lvd":
+	{
+		_unit setUnitTrait ["engineer",true]; // Can repair
+		_unit addBackpack _bag;
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addItem "ToolKit";
+		_unit addweapon _binoculars;
+	};
 // Vehicle Commander Loadout:
 	case "vc":
 	{

--- a/f/assignGear/f_assignGear_npr.sqf
+++ b/f/assignGear/f_assignGear_npr.sqf
@@ -34,6 +34,8 @@
 //		hsamag		- heavy SAM assistant gunner (deployable)
 //		sn			- sniper
 //		sp			- spotter (for sniper)
+//		lvc			- light vehicle crew
+//		lvd			- light vehicle driver (repair)
 //		vc			- vehicle commander
 //		vg			- vehicle gunner
 //		vd			- vehicle driver (repair)

--- a/f/assignGear/f_assignGear_npr_standard.sqf
+++ b/f/assignGear/f_assignGear_npr_standard.sqf
@@ -423,6 +423,29 @@ switch (_typeofUnit) do
 		_unit addWeapon "Rangefinder";
 		_unit addmagazines [_SNrifleMag, 3];
 	};
+// Light Vehicle Crew Loadout:
+	case "lvc":
+	{
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addweapon _binoculars;
+	};
+// Light Vehicle Driver Loadout:
+	case "lvd":
+	{
+		_unit setUnitTrait ["engineer",true]; // Can repair
+		_unit addBackpack _bag;
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addItem "ToolKit";
+		_unit addweapon _binoculars;
+	};
 // Vehicle Commander Loadout:
 	case "vc":
 	{

--- a/f/assignGear/f_assignGear_spetsnaz.sqf
+++ b/f/assignGear/f_assignGear_spetsnaz.sqf
@@ -34,6 +34,8 @@
 //		hsamag		- heavy SAM assistant gunner (deployable)
 //		sn			- sniper
 //		sp			- spotter (for sniper)
+//		lvc			- light vehicle crew
+//		lvd			- light vehicle driver (repair)
 //		vc			- vehicle commander
 //		vg			- vehicle gunner
 //		vd			- vehicle driver (repair)

--- a/f/assignGear/f_assignGear_spetsnaz_standard.sqf
+++ b/f/assignGear/f_assignGear_spetsnaz_standard.sqf
@@ -424,6 +424,29 @@ switch (_typeofUnit) do
 		_unit addWeapon "Rangefinder";
 		_unit addmagazines [_SNrifleMag, 3];
 	};
+// Light Vehicle Crew Loadout:
+	case "lvc":
+	{
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addweapon _binoculars;
+	};
+// Light Vehicle Driver Loadout:
+	case "lvd":
+	{
+		_unit setUnitTrait ["engineer",true]; // Can repair
+		_unit addBackpack _bag;
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addItem "ToolKit";
+		_unit addweapon _binoculars;
+	};
 // Vehicle Commander Loadout:
 	case "vc":
 	{

--- a/f/assignGear/f_assignGear_syndikat.sqf
+++ b/f/assignGear/f_assignGear_syndikat.sqf
@@ -34,6 +34,8 @@
 //		hsamag		- heavy SAM assistant gunner (deployable)
 //		sn			- sniper
 //		sp			- spotter (for sniper)
+//		lvc			- light vehicle crew
+//		lvd			- light vehicle driver (repair)
 //		vc			- vehicle commander
 //		vg			- vehicle gunner
 //		vd			- vehicle driver (repair)

--- a/f/assignGear/f_assignGear_syndikat_standard.sqf
+++ b/f/assignGear/f_assignGear_syndikat_standard.sqf
@@ -420,6 +420,29 @@ switch (_typeofUnit) do
 		_unit addWeapon "Rangefinder";
 		_unit addmagazines [_SNrifleMag, 3];
 	};
+// Light Vehicle Crew Loadout:
+	case "lvc":
+	{
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addweapon _binoculars;
+	};
+// Light Vehicle Driver Loadout:
+	case "lvd":
+	{
+		_unit setUnitTrait ["engineer",true]; // Can repair
+		_unit addBackpack _bag;
+		_unit addmagazines [_carbinemag, 1];
+		_unit addweapon _carbine;
+		_unit addItem _firstaid;
+		_unit addmagazines [_smokegrenadeblue, 3];
+		_unit addmagazines [_carbinemag, 4];
+		_unit addItem "ToolKit";
+		_unit addweapon _binoculars;
+	};
 // Vehicle Commander Loadout:
 	case "vc":
 	{

--- a/mission.sqm
+++ b/mission.sqm
@@ -10400,7 +10400,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="[this,""npr""] call f_fnc_setVirtualFaction; [""vd"",this] call f_fnc_assignGear;";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""lvd"",this] call f_fnc_assignGear;";
 						name="UnitNPR_IFV1_D";
 						description="NPR Technical 1 Driver (Repair)";
 						isPlayable=1;
@@ -10445,7 +10445,7 @@ class Mission
 					{
 						skill=0.60000002;
 						rank="CORPORAL";
-						init="[this,""npr""] call f_fnc_setVirtualFaction; [""vg"",this] call f_fnc_assignGear;";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""lvc"",this] call f_fnc_assignGear;";
 						name="UnitNPR_IFV1_G";
 						description="NPR Technical 1 Gunner";
 						isPlayable=1;
@@ -10578,7 +10578,7 @@ class Mission
 					{
 						skill=0.60000002;
 						rank="CORPORAL";
-						init="[this,""npr""] call f_fnc_setVirtualFaction; [""vg"",this] call f_fnc_assignGear;";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""lvc"",this] call f_fnc_assignGear;";
 						name="UnitNPR_IFV2_G";
 						description="NPR Technical 2 Gunner";
 						isPlayable=1;
@@ -10622,7 +10622,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="[this,""npr""] call f_fnc_setVirtualFaction; [""vd"",this] call f_fnc_assignGear;";
+						init="[this,""npr""] call f_fnc_setVirtualFaction; [""lvd"",this] call f_fnc_assignGear;";
 						name="UnitNPR_IFV2_D";
 						description="NPR Technical 2 Driver (Repair)";
 						isPlayable=1;
@@ -36056,7 +36056,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="[""vd"",this] call f_fnc_assignGear;";
+						init="[""lvd"",this] call f_fnc_assignGear;";
 						name="UnitFIA_IFV1_D";
 						description="FIA Technical 1 Driver (Repair)";
 						isPlayable=1;
@@ -36101,7 +36101,7 @@ class Mission
 					{
 						skill=0.60000002;
 						rank="CORPORAL";
-						init="[""vg"",this] call f_fnc_assignGear;";
+						init="[""lvc"",this] call f_fnc_assignGear;";
 						name="UnitFIA_IFV1_G";
 						description="FIA Technical 1 Gunner";
 						isPlayable=1;
@@ -36215,7 +36215,7 @@ class Mission
 					{
 						skill=0.60000002;
 						rank="CORPORAL";
-						init="[""vg"",this] call f_fnc_assignGear;";
+						init="[""lvc"",this] call f_fnc_assignGear;";
 						name="UnitFIA_IFV2_G";
 						description="FIA Technical 2 Gunner";
 						isPlayable=1;
@@ -36259,7 +36259,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="[""vd"",this] call f_fnc_assignGear;";
+						init="[""lvd"",this] call f_fnc_assignGear;";
 						name="UnitFIA_IFV2_D";
 						description="FIA Technical 2 Driver (Repair)";
 						isPlayable=1;
@@ -41687,7 +41687,7 @@ class Mission
 					class Attributes
 					{
 						rank="CORPORAL";
-						init="[""vg"",this] call f_fnc_assignGear;";
+						init="[""lvc"",this] call f_fnc_assignGear;";
 						name="UnitSyn_IFV1_G";
 						description="Syndikat Technical 1 Gunner";
 						isPlayable=1;
@@ -41730,7 +41730,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="[""vd"",this] call f_fnc_assignGear;";
+						init="[""lvd"",this] call f_fnc_assignGear;";
 						name="UnitSyn_IFV1_D";
 						description="Syndikat Technical 1 Driver (Repair)";
 						isPlayable=1;
@@ -41862,7 +41862,7 @@ class Mission
 					class Attributes
 					{
 						rank="CORPORAL";
-						init="[""vg"",this] call f_fnc_assignGear;";
+						init="[""lvc"",this] call f_fnc_assignGear;";
 						name="UnitSyn_IFV2_G";
 						description="Syndikat Technical 2 Gunner";
 						isPlayable=1;
@@ -41905,7 +41905,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="[""vd"",this] call f_fnc_assignGear;";
+						init="[""lvd"",this] call f_fnc_assignGear;";
 						name="UnitSyn_IFV2_D";
 						description="Syndikat Technical 2 Driver (Repair)";
 						isPlayable=1;
@@ -50095,7 +50095,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="[this,""3ifb""] call f_fnc_setVirtualFaction; [""vd"",this] call f_fnc_assignGear;";
+						init="[this,""3ifb""] call f_fnc_setVirtualFaction; [""lvd"",this] call f_fnc_assignGear;";
 						name="Unit3IFB_IFV1_D";
 						description="3IFB Technical 1 Driver (Repair)";
 						isPlayable=1;
@@ -50140,7 +50140,7 @@ class Mission
 					{
 						skill=0.60000002;
 						rank="CORPORAL";
-						init="[this,""3ifb""] call f_fnc_setVirtualFaction; [""vg"",this] call f_fnc_assignGear;";
+						init="[this,""3ifb""] call f_fnc_setVirtualFaction; [""lvc"",this] call f_fnc_assignGear;";
 						name="Unit3IFB_IFV1_G";
 						description="3IFB Technical 1 Gunner";
 						isPlayable=1;
@@ -50254,7 +50254,7 @@ class Mission
 					{
 						skill=0.60000002;
 						rank="CORPORAL";
-						init="[this,""3ifb""] call f_fnc_setVirtualFaction; [""vg"",this] call f_fnc_assignGear;";
+						init="[this,""3ifb""] call f_fnc_setVirtualFaction; [""lvc"",this] call f_fnc_assignGear;";
 						name="Unit3IFB_IFV2_G";
 						description="3IFB Technical 2 Gunner";
 						isPlayable=1;
@@ -50298,7 +50298,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="[this,""3ifb""] call f_fnc_setVirtualFaction; [""vd"",this] call f_fnc_assignGear;";
+						init="[this,""3ifb""] call f_fnc_setVirtualFaction; [""lvd"",this] call f_fnc_assignGear;";
 						name="Unit3IFB_IFV2_D";
 						description="3IFB Technical 2 Driver (Repair)";
 						isPlayable=1;


### PR DESCRIPTION
Per #290, this adds new Light Vehicle crew classes to assignGear.

"lvc" Light Vehicle Crew - identical to "vc" except it gets a carbine
"lvd" Light Vehicle Driver - identical to "vd" except it gets a carbine and binocs

Notes:
- new classes receive the standard uniforms, helmets, and rigs as they are not included in any of the special outfit arrays
- not added to light loadouts due to pending removal of light loadouts
- already has binocs as a variable due to pending change
- added Crew instead of Commander/Gunner as few light vehicles require a third crew-member and there would be no difference in gear anyway
- drivers get binocs because they usually have the best opportunity to use them in a light vehicle crew