### PR TITLE
#331 added __has_include protection to createBriefing and assignGear

### DIFF
--- a/f/assignGear/fn_assignGear.sqf
+++ b/f/assignGear/fn_assignGear.sqf
@@ -78,9 +78,19 @@ if (f_param_debugMode == 1) then
 // automatically includes a file which contains the appropriate equipment data.
 
 if (_faction in ["blu_f","nato"]) then {
-	#include "f_assignGear_nato.sqf"
-	// #include "f_assignGear_natoPacific.sqf" // Use NATO Pacific loadouts on NATO non-Pacific units (e.g. Folk ARPS Platoons)
-	// #include "f_assignGear_natoWoodland.sqf" // Use NATO Woodland loadouts on NATO non-Woodland units (e.g. Folk ARPS Platoons)
+	#if __has_include("f_assignGear_nato.sqf")
+		#include "f_assignGear_nato.sqf"
+	#endif
+
+	// Use NATO Pacific loadouts on NATO non-Pacific units (e.g. Folk ARPS Platoons)
+	// #if __has_include("f_assignGear_natoPacific.sqf")
+		// #include "f_assignGear_natoPacific.sqf"
+	// #endif
+
+	// Use NATO Woodland loadouts on NATO non-Woodland units (e.g. Folk ARPS Platoons)
+	// #if __has_include("f_assignGear_natoWoodland.sqf")
+		// #include "f_assignGear_natoWoodland.sqf"
+	// #endif
 };
 
 // ====================================================================================
@@ -90,7 +100,9 @@ if (_faction in ["blu_f","nato"]) then {
 // automatically includes a file which contains the appropriate equipment data.
 
 if (_faction in ["blu_t_f","natopacific"]) then {
-	#include "f_assignGear_natoPacific.sqf"
+	#if __has_include("f_assignGear_natoPacific.sqf")
+		#include "f_assignGear_natoPacific.sqf"
+	#endif
 };
 
 // ====================================================================================
@@ -100,7 +112,9 @@ if (_faction in ["blu_t_f","natopacific"]) then {
 // automatically includes a file which contains the appropriate equipment data.
 
 if (_faction in ["blu_w_f","natowoodland"]) then {
-	#include "f_assignGear_natoWoodland.sqf"
+	#if __has_include("f_assignGear_natoWoodland.sqf")
+		#include "f_assignGear_natoWoodland.sqf"
+	#endif
 };
 
 // ====================================================================================
@@ -110,7 +124,9 @@ if (_faction in ["blu_w_f","natowoodland"]) then {
 // automatically includes a file which contains the appropriate equipment data.
 
 if (_faction in ["blu_gen_f"]) then {
-	#include "f_assignGear_gendarmerie.sqf"
+	#if __has_include("f_assignGear_gendarmerie.sqf")
+		#include "f_assignGear_gendarmerie.sqf"
+	#endif
 };
 
 // ====================================================================================
@@ -120,8 +136,14 @@ if (_faction in ["blu_gen_f"]) then {
 // automatically includes a file which contains the appropriate equipment data.
 
 if (_faction in ["opf_f","csat"]) then {
-	#include "f_assignGear_csat.sqf"
-	// #include "f_assignGear_csatPacific.sqf" // Use CSAT Pacific loadouts on CSAT non-Pacific units (e.g. Folk ARPS Platoons)
+	#if __has_include("f_assignGear_csat.sqf")
+		#include "f_assignGear_csat.sqf"
+	#endif
+
+	// Use CSAT Pacific loadouts on CSAT non-Pacific units (e.g. Folk ARPS Platoons)
+	// #if __has_include("f_assignGear_csatPacific.sqf")
+		// #include "f_assignGear_csatPacific.sqf"
+	// #endif
 };
 
 // ====================================================================================
@@ -131,7 +153,9 @@ if (_faction in ["opf_f","csat"]) then {
 // automatically includes a file which contains the appropriate equipment data.
 
 if (_faction in ["opf_t_f","csatpacific"]) then {
-	#include "f_assignGear_csatPacific.sqf"
+	#if __has_include("f_assignGear_csatPacific.sqf")
+		#include "f_assignGear_csatPacific.sqf"
+	#endif
 };
 
 // ====================================================================================
@@ -141,7 +165,9 @@ if (_faction in ["opf_t_f","csatpacific"]) then {
 // automatically includes a file which contains the appropriate equipment data.
 
 if (_faction in ["opf_r_f","spetsnaz"]) then {
-	#include "f_assignGear_spetsnaz.sqf"
+	#if __has_include("f_assignGear_spetsnaz.sqf")
+		#include "f_assignGear_spetsnaz.sqf"
+	#endif
 };
 
 // ====================================================================================
@@ -151,7 +177,9 @@ if (_faction in ["opf_r_f","spetsnaz"]) then {
 // automatically includes a file which contains the appropriate equipment data.
 
 if (_faction in ["ind_f","aaf"]) then {
-	#include "f_assignGear_aaf.sqf"
+	#if __has_include("f_assignGear_aaf.sqf")
+		#include "f_assignGear_aaf.sqf"
+	#endif
 };
 
 // ====================================================================================
@@ -161,7 +189,9 @@ if (_faction in ["ind_f","aaf"]) then {
 // automatically includes a file which contains the appropriate equipment data.
 
 if (_faction in ["blu_g_f","opf_g_f","ind_g_f","fia"]) then {
-	#include "f_assignGear_fia.sqf"
+	#if __has_include("f_assignGear_fia.sqf")
+		#include "f_assignGear_fia.sqf"
+	#endif
 };
 
 // ====================================================================================
@@ -171,7 +201,9 @@ if (_faction in ["blu_g_f","opf_g_f","ind_g_f","fia"]) then {
 // automatically includes a file which contains the appropriate equipment data.
 
 if (_faction in ["blu_ctrg_f","ctrg"]) then {
-	#include "f_assignGear_ctrg.sqf"
+	#if __has_include("f_assignGear_ctrg.sqf")
+		#include "f_assignGear_ctrg.sqf"
+	#endif
 };
 
 // ====================================================================================
@@ -181,7 +213,9 @@ if (_faction in ["blu_ctrg_f","ctrg"]) then {
 // automatically includes a file which contains the appropriate equipment data.
 
 if (_faction in ["ind_c_f","syndikat"]) then {
-	#include "f_assignGear_syndikat.sqf"
+	#if __has_include("f_assignGear_syndikat.sqf")
+		#include "f_assignGear_syndikat.sqf"
+	#endif
 };
 
 // ====================================================================================
@@ -191,7 +225,9 @@ if (_faction in ["ind_c_f","syndikat"]) then {
 // automatically includes a file which contains the appropriate equipment data.
 
 if (_faction in ["ind_e_f","ldf"]) then {
-	#include "f_assignGear_ldf.sqf"
+	#if __has_include("f_assignGear_ldf.sqf")
+		#include "f_assignGear_ldf.sqf"
+	#endif
 };
 
 // ====================================================================================
@@ -201,7 +237,9 @@ if (_faction in ["ind_e_f","ldf"]) then {
 // automatically includes a file which contains the appropriate equipment data.
 
 if (_faction in ["ind_l_f","npr"]) then {
-	#include "f_assignGear_npr.sqf"
+	#if __has_include("f_assignGear_npr.sqf")
+		#include "f_assignGear_npr.sqf"
+	#endif
 };
 
 // ====================================================================================
@@ -213,7 +251,9 @@ if (_faction in ["ind_l_f","npr"]) then {
 // with f_fnc_setVirtualFaction; it automatically includes a file which contains the appropriate
 // equipment data.
 if (_faction in ["3ifb"]) then {
-	#include "f_assignGear_3IFB.sqf"
+	#if __has_include("f_assignGear_3IFB.sqf")
+		#include "f_assignGear_3IFB.sqf"
+	#endif
 };
 
 // ====================================================================================

--- a/f/briefing/fn_createBriefing.sqf
+++ b/f/briefing/fn_createBriefing.sqf
@@ -41,121 +41,121 @@ if (f_param_debugMode == 1) then
 // ====================================================================================
 
 // BRIEFING: ADMIN
-if (serverCommandAvailable "#kick" || !isMultiplayer) then {
-	#if __has_include("f_briefing_admin.sqf")
+#if __has_include("f_briefing_admin.sqf")
+	if (serverCommandAvailable "#kick" || !isMultiplayer) then {
 		#include "f_briefing_admin.sqf"
 		["host"] call _fnc_debug;
-	#endif
-};
+	};
+#endif
 
 // ====================================================================================
 // BRIEFING: FACTION SPECIFIC
 // The following code blocks include faction-specific briefing files.
 
 // BLUFOR > NATO
-if (_unitfaction in ["blu_f","blu_t_f","blu_w_f","nato","natowoodland","natopacific"]) exitwith {
-	#if __has_include("f_briefing_nato.sqf")
+#if __has_include("f_briefing_nato.sqf")
+	if (_unitfaction in ["blu_f","blu_t_f","blu_w_f","nato","natowoodland","natopacific"]) exitwith {
 		#include "f_briefing_nato.sqf"
 		[_unitfaction] call _fnc_debug;
-	#endif
-};
+	};
+#endif
 
 // FIA
-if (_unitfaction in ["blu_g_f","ind_g_f","opf_g_f","fia"]) exitwith {
-	#if __has_include("f_briefing_fia.sqf")
+#if __has_include("f_briefing_fia.sqf")
+	if (_unitfaction in ["blu_g_f","ind_g_f","opf_g_f","fia"]) exitwith {
 		#include "f_briefing_fia.sqf"
 		[_unitfaction] call _fnc_debug;
-	#endif
-};
+	};
+#endif
 
 // BLUFOR > GENDARMERIE
-if (_unitfaction in ["blu_gen_f"]) exitwith {
-	#if __has_include("f_briefing_gendarmerie.sqf")
+#if __has_include("f_briefing_gendarmerie.sqf")
+	if (_unitfaction in ["blu_gen_f"]) exitwith {
 		#include "f_briefing_gendarmerie.sqf"
 		[_unitfaction] call _fnc_debug;
-	#endif
-};
+	};
+#endif
 
 // OPFOR > CSAT
-if (_unitfaction in ["opf_f","opf_t_f","csat","csatpacific"]) exitwith {
-	#if __has_include("f_briefing_csat.sqf")
+#if __has_include("f_briefing_csat.sqf")
+	if (_unitfaction in ["opf_f","opf_t_f","csat","csatpacific"]) exitwith {
 		#include "f_briefing_csat.sqf"
 		[_unitfaction] call _fnc_debug;
-	#endif
-};
+	};
+#endif
 
 // OPFOR > Spetsnaz
-if (_unitfaction in ["opf_r_f","spetsnaz"]) exitwith {
-	#if __has_include("f_briefing_spetsnaz.sqf")
+#if __has_include("f_briefing_spetsnaz.sqf")
+	if (_unitfaction in ["opf_r_f","spetsnaz"]) exitwith {
 		#include "f_briefing_spetsnaz.sqf"
 		[_unitfaction] call _fnc_debug;
-	#endif
-};
+	};
+#endif
 
 // INDEPENDENT > AAF
-if (_unitfaction in ["ind_f","aaf"]) exitwith {
-	#if __has_include("f_briefing_aaf.sqf")
+#if __has_include("f_briefing_aaf.sqf")
+	if (_unitfaction in ["ind_f","aaf"]) exitwith {
 		#include "f_briefing_aaf.sqf"
 		[_unitfaction] call _fnc_debug;
-	#endif
-};
+	};
+#endif
 
 // INDEPENDENT > LDF
-if (_unitfaction in ["ind_e_f","ldf"]) exitwith {
-	#if __has_include("f_briefing_ldf.sqf")
+#if __has_include("f_briefing_ldf.sqf")
+	if (_unitfaction in ["ind_e_f","ldf"]) exitwith {
 		#include "f_briefing_ldf.sqf"
 		[_unitfaction] call _fnc_debug;
-	#endif
-};
+	};
+#endif
 
 // INDEPENDENT > SYNDIKAT
-if (_unitfaction in ["ind_c_f","syndikat"]) exitwith {
-	#if __has_include("f_briefing_syndikat.sqf")
+#if __has_include("f_briefing_syndikat.sqf")
+	if (_unitfaction in ["ind_c_f","syndikat"]) exitwith {
 		#include "f_briefing_syndikat.sqf"
 		[_unitfaction] call _fnc_debug;
-	#endif
-};
+	};
+#endif
 
 // INDEPENDENT > NPR (Looters)
-if (_unitfaction in ["ind_l_f","npr"]) exitwith {
-	#if __has_include("f_briefing_npr.sqf")
+#if __has_include("f_briefing_npr.sqf")
+	if (_unitfaction in ["ind_l_f","npr"]) exitwith {
 		#include "f_briefing_npr.sqf"
 		[_unitfaction] call _fnc_debug;
-	#endif
-};
+	};
+#endif
 
 
 // BLUFOR > CTRG
-if (_unitfaction in ["blu_ctrg_f","ctrg"]) exitwith {
-	#if __has_include("f_briefing_ctrg.sqf")
+#if __has_include("f_briefing_ctrg.sqf")
+	if (_unitfaction in ["blu_ctrg_f","ctrg"]) exitwith {
 		#include "f_briefing_ctrg.sqf"
 		[_unitfaction] call _fnc_debug;
-	#endif
-};
+	};
+#endif
 
 // CIVILIAN and IDAP
-if (_unitfaction in ["civ_f", "civ_idap_f"]) exitwith {
-	#if __has_include("f_briefing_civ.sqf")
+#if __has_include("f_briefing_civ.sqf")
+	if (_unitfaction in ["civ_f", "civ_idap_f"]) exitwith {
 		#include "f_briefing_civ.sqf"
 		[_unitfaction] call _fnc_debug;
-	#endif
-};
+	};
+#endif
 
 // VIRTUAL FACTION > 3IFB
-if (_unitfaction in ["3ifb"]) exitwith {
-	#if __has_include("f_briefing_3ifb.sqf")
+#if __has_include("f_briefing_3ifb.sqf")
+	if (_unitfaction in ["3ifb"]) exitwith {
 		#include "f_briefing_3ifb.sqf"
 		[_unitfaction] call _fnc_debug;
-	#endif
-};
+	};
+#endif
 
 // ZEUS
-if (_unitfaction == "" && ! (typeOf player isEqualTo "VirtualSpectator_F")) exitwith {
-	#if __has_include("f_briefing_zeus.sqf")
+#if __has_include("f_briefing_zeus.sqf")
+	if (_unitfaction == "" && ! (typeOf player isEqualTo "VirtualSpectator_F")) exitwith {
 		#include "f_briefing_zeus.sqf"
 		[_unitfaction] call _fnc_debug;
-	#endif
-};
+	};
+#endif
 
 // Virtual Spectator
 if (typeOf player isEqualTo "VirtualSpectator_F") exitwith {

--- a/f/briefing/fn_createBriefing.sqf
+++ b/f/briefing/fn_createBriefing.sqf
@@ -34,14 +34,18 @@ if (f_param_debugMode == 1) then
 // ====================================================================================
 
 // BRIEFING: CREDITS
-#include "f_briefing_credits.sqf"
+#if __has_include("f_briefing_credits.sqf")
+	#include "f_briefing_credits.sqf"
+#endif
 
 // ====================================================================================
 
 // BRIEFING: ADMIN
 if (serverCommandAvailable "#kick" || !isMultiplayer) then {
-	#include "f_briefing_admin.sqf"
-	["host"] call _fnc_debug;
+	#if __has_include("f_briefing_admin.sqf")
+		#include "f_briefing_admin.sqf"
+		["host"] call _fnc_debug;
+	#endif
 };
 
 // ====================================================================================
@@ -50,81 +54,107 @@ if (serverCommandAvailable "#kick" || !isMultiplayer) then {
 
 // BLUFOR > NATO
 if (_unitfaction in ["blu_f","blu_t_f","blu_w_f","nato","natowoodland","natopacific"]) exitwith {
-	#include "f_briefing_nato.sqf"
-	[_unitfaction] call _fnc_debug;
+	#if __has_include("f_briefing_nato.sqf")
+		#include "f_briefing_nato.sqf"
+		[_unitfaction] call _fnc_debug;
+	#endif
 };
 
 // FIA
 if (_unitfaction in ["blu_g_f","ind_g_f","opf_g_f","fia"]) exitwith {
-	#include "f_briefing_fia.sqf"
-	[_unitfaction] call _fnc_debug;
+	#if __has_include("f_briefing_fia.sqf")
+		#include "f_briefing_fia.sqf"
+		[_unitfaction] call _fnc_debug;
+	#endif
 };
 
 // BLUFOR > GENDARMERIE
 if (_unitfaction in ["blu_gen_f"]) exitwith {
-	#include "f_briefing_gendarmerie.sqf"
-	[_unitfaction] call _fnc_debug;
+	#if __has_include("f_briefing_gendarmerie.sqf")
+		#include "f_briefing_gendarmerie.sqf"
+		[_unitfaction] call _fnc_debug;
+	#endif
 };
 
 // OPFOR > CSAT
 if (_unitfaction in ["opf_f","opf_t_f","csat","csatpacific"]) exitwith {
-	#include "f_briefing_csat.sqf"
-	[_unitfaction] call _fnc_debug;
+	#if __has_include("f_briefing_csat.sqf")
+		#include "f_briefing_csat.sqf"
+		[_unitfaction] call _fnc_debug;
+	#endif
 };
 
 // OPFOR > Spetsnaz
 if (_unitfaction in ["opf_r_f","spetsnaz"]) exitwith {
-	#include "f_briefing_spetsnaz.sqf"
-	[_unitfaction] call _fnc_debug;
+	#if __has_include("f_briefing_spetsnaz.sqf")
+		#include "f_briefing_spetsnaz.sqf"
+		[_unitfaction] call _fnc_debug;
+	#endif
 };
 
 // INDEPENDENT > AAF
 if (_unitfaction in ["ind_f","aaf"]) exitwith {
-	#include "f_briefing_aaf.sqf"
-	[_unitfaction] call _fnc_debug;
+	#if __has_include("f_briefing_aaf.sqf")
+		#include "f_briefing_aaf.sqf"
+		[_unitfaction] call _fnc_debug;
+	#endif
 };
 
 // INDEPENDENT > LDF
 if (_unitfaction in ["ind_e_f","ldf"]) exitwith {
-	#include "f_briefing_ldf.sqf"
-	[_unitfaction] call _fnc_debug;
+	#if __has_include("f_briefing_ldf.sqf")
+		#include "f_briefing_ldf.sqf"
+		[_unitfaction] call _fnc_debug;
+	#endif
 };
 
 // INDEPENDENT > SYNDIKAT
 if (_unitfaction in ["ind_c_f","syndikat"]) exitwith {
-	#include "f_briefing_syndikat.sqf"
-	[_unitfaction] call _fnc_debug;
+	#if __has_include("f_briefing_syndikat.sqf")
+		#include "f_briefing_syndikat.sqf"
+		[_unitfaction] call _fnc_debug;
+	#endif
 };
 
 // INDEPENDENT > NPR (Looters)
 if (_unitfaction in ["ind_l_f","npr"]) exitwith {
-	#include "f_briefing_npr.sqf"
-	[_unitfaction] call _fnc_debug;
+	#if __has_include("f_briefing_npr.sqf")
+		#include "f_briefing_npr.sqf"
+		[_unitfaction] call _fnc_debug;
+	#endif
 };
 
 
 // BLUFOR > CTRG
 if (_unitfaction in ["blu_ctrg_f","ctrg"]) exitwith {
-	#include "f_briefing_ctrg.sqf"
-	[_unitfaction] call _fnc_debug;
+	#if __has_include("f_briefing_ctrg.sqf")
+		#include "f_briefing_ctrg.sqf"
+		[_unitfaction] call _fnc_debug;
+	#endif
 };
 
 // CIVILIAN and IDAP
 if (_unitfaction in ["civ_f", "civ_idap_f"]) exitwith {
-	#include "f_briefing_civ.sqf"
-	[_unitfaction] call _fnc_debug;
+	#if __has_include("f_briefing_civ.sqf")
+		#include "f_briefing_civ.sqf"
+		[_unitfaction] call _fnc_debug;
+	#endif
 };
 
 // VIRTUAL FACTION > 3IFB
 if (_unitfaction in ["3ifb"]) exitwith {
-	#include "f_briefing_3ifb.sqf"
-	[_unitfaction] call _fnc_debug;
+	#if __has_include("f_briefing_3ifb.sqf")
+		#include "f_briefing_3ifb.sqf"
+		[_unitfaction] call _fnc_debug;
+	#endif
 };
 
 // ZEUS
 if (_unitfaction == "" && ! (typeOf player isEqualTo "VirtualSpectator_F")) exitwith {
-	#include "f_briefing_zeus.sqf"
-	["zeus"] call _fnc_debug;
+	#if __has_include("f_briefing_zeus.sqf")
+		#include "f_briefing_zeus.sqf"
+		[_unitfaction] call _fnc_debug;
+	#endif
 };
 
 // Virtual Spectator

--- a/f/briefing/fn_createBriefing.sqf
+++ b/f/briefing/fn_createBriefing.sqf
@@ -153,7 +153,7 @@ if (f_param_debugMode == 1) then
 #if __has_include("f_briefing_zeus.sqf")
 	if (_unitfaction == "" && ! (typeOf player isEqualTo "VirtualSpectator_F")) exitwith {
 		#include "f_briefing_zeus.sqf"
-		[_unitfaction] call _fnc_debug;
+		["zeus"] call _fnc_debug;
 	};
 #endif
 


### PR DESCRIPTION
#331 

Tested locally. AssignGear and createBriefing appear to work correctly, and the game doesn't crash if you delete all the affected files. createBriefing looks a bit complex because it needs to bypass the exitWith or it won't detect that a briefing hasn't been loaded.