### PR TITLE
Issue #329: Make CasCap work with reinforcements

### DIFF
--- a/f/casualtiesCap/f_CasualtiesCapCheck.sqf
+++ b/f/casualtiesCap/f_CasualtiesCapCheck.sqf
@@ -51,19 +51,9 @@ if(_grpstemp isEqualType sideUnknown) then // if the variable is any of the side
 {
 
 	{
-		if(_onlyPlayers) then
+		if (side _x == _grpstemp) then
 		{
-			if((side _x == _grpstemp) && (leader _x in playableUnits)) then
-			{
-				_grps pushBack _x; // Add group to array
-			};
-		}
-		else
-		{
-			if (side _x == _grpstemp) then
-			{
-				_grps pushBack _x; // Add group to array
-			};
+			_grps pushBack _x; // Add group to array
 		};
 
 	} forEach allGroups;
@@ -106,24 +96,12 @@ if (count _grps == 0) exitWith {
 
 // ====================================================================================
 
-// CREATE STARTING VALUES
-// A count is made of units in the groups listed in _grps.
-
-_started = 0;
-{_started = _started + (count (units _x))} forEach _grps;
-
-// DEBUG
-if (f_param_debugMode == 1) then
-{
-	player sideChat format ["DEBUG (f\casualtiesCap\f_CasualtiesCapCheck.sqf): _started = %1",_started];
-};
-
-// ====================================================================================
-
 // CHECK IF CASUALTIES CAP HAS BEEN REACHED OR EXCEEDED
 // Every 6 seconds the server will check to see if the number of casualties sustained
 // within the group(s) has reached the percentage specificed in the variable _pc. If
 // the cap has been reached, the loop will exit to trigger the ending.
+
+_started = 0;
 
 while {true} do
 {
@@ -133,8 +111,23 @@ while {true} do
 	{
 		_grp = _x;
 		_alive = {alive _x} count (units _grp);
-		_remaining = _remaining + _alive;
+		
+		// Only count units if leader is a player or if we want to include AI
+		if( !_onlyPlayers || (leader _grp in playableUnits) ) then {
+			_remaining = _remaining + _alive;
+		};
+
 	} forEach _grps;
+
+
+	if(_started == 0) then {
+		_started = _remaining;
+		// DEBUG
+		if (f_param_debugMode == 1) then
+		{
+			player sideChat format ["DEBUG (f\casualtiesCap\f_CasualtiesCapCheck.sqf): _started = %1",_started];
+		};
+	}
 
 // DEBUG
 	if (f_param_debugMode == 1) then


### PR DESCRIPTION
See #329.

Previously, the problem was that the `_onlyPlayers` was set to true by default and then at the beginning, it only used groups that had a playable leader. I have moved this check into the loop now, such that previously empty groups are also counted if they have players.

Also, i set the `_started` variable in the same loop to avoid duplicating the unit-counting logic.